### PR TITLE
WIP: Add cleanroom docs audit command

### DIFF
--- a/src/programbench/cli/main.py
+++ b/src/programbench/cli/main.py
@@ -96,6 +96,42 @@ def eval(
     )
 
 
+@app.command("audit-cleanroom-docs")
+def audit_cleanroom_docs(
+    targets: list[str] = typer.Argument(
+        ...,
+        help="Cleanroom image refs or ProgramBench instance IDs to audit",
+    ),
+    image_tag: str = typer.Option("task_cleanroom", "--image-tag", help="Image tag to use for instance IDs"),
+    timeout: float = typer.Option(60, "--timeout", help="Per registry request timeout in seconds"),
+) -> None:
+    """Check cleanroom images for documentation directories."""
+    from rich.console import Console
+
+    from programbench.constants import image_name_from_instance_id
+    from programbench.utils.cleanroom_audit import audit_cleanroom_image
+
+    console = Console()
+    failed = False
+    for target in targets:
+        image = target if "/" in target else f"{image_name_from_instance_id(target)}:{image_tag}"
+        audit = audit_cleanroom_image(image, timeout=timeout)
+        status = "ok" if audit.ok else "missing-docs"
+        console.print(f"{image}: {status}")
+        console.print(f"  documentation entries: {len(audit.doc_entries)}")
+        console.print(f"  README-like entries: {', '.join(audit.readme_entries) or '-'}")
+        console.print(f"  LICENSE-like entries: {', '.join(audit.license_entries) or '-'}")
+        for whiteout in audit.doc_whiteouts:
+            console.print(
+                f"  doc whiteout: layer {whiteout.layer} {whiteout.path} "
+                f"removed {whiteout.target} ({whiteout.removed_paths} tracked paths)"
+            )
+        failed = failed or not audit.ok
+
+    if failed:
+        raise typer.Exit(1)
+
+
 @app.command()
 def info(
     run_dir: Path = typer.Argument(..., help="Run directory containing <instance_id>/<instance_id>.eval.json"),

--- a/src/programbench/utils/cleanroom_audit.py
+++ b/src/programbench/utils/cleanroom_audit.py
@@ -1,0 +1,211 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import gzip
+import json
+import posixpath
+import tarfile
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass, field
+from typing import BinaryIO, Iterable
+
+
+DEFAULT_REGISTRY = "registry-1.docker.io"
+DOCKER_AUTH_URL = "https://auth.docker.io/token"
+MANIFEST_ACCEPT = ", ".join(
+    [
+        "application/vnd.oci.image.index.v1+json",
+        "application/vnd.docker.distribution.manifest.list.v2+json",
+        "application/vnd.oci.image.manifest.v1+json",
+        "application/vnd.docker.distribution.manifest.v2+json",
+    ]
+)
+WORKSPACE_PREFIX = "workspace/"
+DOC_DIRS = {"doc", "docs", "documentation"}
+
+
+@dataclass(frozen=True)
+class ImageRef:
+    repository: str
+    tag: str
+    registry: str = DEFAULT_REGISTRY
+
+
+@dataclass(frozen=True)
+class Whiteout:
+    layer: int
+    path: str
+    target: str
+    removed_paths: int
+
+
+@dataclass
+class LayeredFileTree:
+    entries: dict[str, str] = field(default_factory=dict)
+    whiteouts: list[Whiteout] = field(default_factory=list)
+
+    def apply_member(self, member: tarfile.TarInfo, *, layer: int) -> None:
+        name = member.name
+        while name.startswith("./"):
+            name = name[2:]
+        if not name:
+            return
+
+        parent, base = posixpath.split(name)
+        if base.startswith(".wh."):
+            self._apply_whiteout(parent, base, layer=layer)
+            return
+
+        if member.isdir():
+            typ = "dir"
+        elif member.isfile():
+            typ = "file"
+        elif member.issym() or member.islnk():
+            typ = "link"
+        else:
+            typ = "other"
+        self.entries[name] = typ
+
+    def _apply_whiteout(self, parent: str, base: str, *, layer: int) -> None:
+        if base == ".wh..wh..opq":
+            prefix = parent.rstrip("/") + "/"
+            removed = [p for p in self.entries if p.startswith(prefix) and p != parent]
+            target = parent
+        else:
+            target = posixpath.join(parent, base[4:]) if parent else base[4:]
+            prefix = target.rstrip("/") + "/"
+            removed = [p for p in self.entries if p == target or p.startswith(prefix)]
+
+        for path in removed:
+            self.entries.pop(path, None)
+        self.whiteouts.append(
+            Whiteout(layer=layer, path=posixpath.join(parent, base), target=target, removed_paths=len(removed))
+        )
+
+
+@dataclass(frozen=True)
+class CleanroomDocsAudit:
+    image: str
+    workspace_entries: dict[str, str]
+    doc_entries: tuple[str, ...]
+    readme_entries: tuple[str, ...]
+    license_entries: tuple[str, ...]
+    doc_whiteouts: tuple[Whiteout, ...]
+
+    @property
+    def has_doc_directory(self) -> bool:
+        return bool(self.doc_entries)
+
+    @property
+    def ok(self) -> bool:
+        return self.has_doc_directory
+
+
+def parse_image_ref(image: str, default_tag: str = "latest") -> ImageRef:
+    tag = default_tag
+    repository = image
+    if ":" in image.rsplit("/", 1)[-1]:
+        repository, tag = image.rsplit(":", 1)
+    if repository.startswith("docker.io/"):
+        repository = repository[len("docker.io/") :]
+    if repository.startswith("library/"):
+        repository = f"library/{repository.split('/', 1)[1]}"
+    return ImageRef(repository=repository, tag=tag)
+
+
+def _json_request(url: str, headers: dict[str, str] | None = None, *, timeout: float) -> dict:
+    req = urllib.request.Request(url, headers=headers or {})
+    with urllib.request.urlopen(req, timeout=timeout) as response:
+        return json.load(response)
+
+
+def _bearer_token(image_ref: ImageRef, *, timeout: float) -> str:
+    query = urllib.parse.urlencode(
+        {"service": "registry.docker.io", "scope": f"repository:{image_ref.repository}:pull"}
+    )
+    data = _json_request(f"{DOCKER_AUTH_URL}?{query}", timeout=timeout)
+    return data["token"]
+
+
+def _manifest(image_ref: ImageRef, token: str, *, timeout: float) -> dict:
+    headers = {"Authorization": f"Bearer {token}", "Accept": MANIFEST_ACCEPT}
+    return _json_request(
+        f"https://{image_ref.registry}/v2/{image_ref.repository}/manifests/{image_ref.tag}",
+        headers,
+        timeout=timeout,
+    )
+
+
+def _blob_url(image_ref: ImageRef, digest: str) -> str:
+    return f"https://{image_ref.registry}/v2/{image_ref.repository}/blobs/{digest}"
+
+
+def _open_layer(stream: BinaryIO, media_type: str) -> tarfile.TarFile:
+    if media_type.endswith("+gzip") or media_type.endswith(".gzip"):
+        return tarfile.open(fileobj=gzip.GzipFile(fileobj=stream), mode="r|")
+    return tarfile.open(fileobj=stream, mode="r|")
+
+
+def apply_tar_layer(stream: BinaryIO, media_type: str, *, layer_index: int, tree: LayeredFileTree) -> None:
+    with _open_layer(stream, media_type) as tar:
+        for member in tar:
+            tree.apply_member(member, layer=layer_index)
+
+
+def apply_tar_layers(layers: Iterable[tuple[BinaryIO, str]], tree: LayeredFileTree | None = None) -> LayeredFileTree:
+    tree = tree or LayeredFileTree()
+    for layer_index, (stream, media_type) in enumerate(layers, 1):
+        apply_tar_layer(stream, media_type, layer_index=layer_index, tree=tree)
+    return tree
+
+
+def audit_entries(image: str, tree: LayeredFileTree) -> CleanroomDocsAudit:
+    workspace_entries = {
+        path[len(WORKSPACE_PREFIX) :]: typ
+        for path, typ in sorted(tree.entries.items())
+        if path.startswith(WORKSPACE_PREFIX) and path != "workspace"
+    }
+    doc_entries = tuple(
+        path for path, typ in workspace_entries.items() if typ != "dir" and path.split("/", 1)[0].lower() in DOC_DIRS
+    )
+    readme_entries = tuple(path for path in workspace_entries if posixpath.basename(path).lower().startswith("readme"))
+    license_entries = tuple(path for path in workspace_entries if "license" in posixpath.basename(path).lower())
+    doc_whiteouts = tuple(
+        whiteout
+        for whiteout in tree.whiteouts
+        if whiteout.target.startswith(WORKSPACE_PREFIX)
+        and whiteout.target[len(WORKSPACE_PREFIX) :].split("/", 1)[0].lower() in DOC_DIRS
+    )
+    return CleanroomDocsAudit(
+        image=image,
+        workspace_entries=workspace_entries,
+        doc_entries=doc_entries,
+        readme_entries=readme_entries,
+        license_entries=license_entries,
+        doc_whiteouts=doc_whiteouts,
+    )
+
+
+def audit_cleanroom_image(image: str, *, timeout: float = 60) -> CleanroomDocsAudit:
+    image_ref = parse_image_ref(image)
+    token = _bearer_token(image_ref, timeout=timeout)
+    manifest = _manifest(image_ref, token, timeout=timeout)
+
+    layers = manifest.get("layers")
+    if layers is None:
+        raise ValueError(f"Expected image manifest for {image}, got {manifest.get('mediaType')}")
+
+    headers = {"Authorization": f"Bearer {token}"}
+    tree = LayeredFileTree()
+    for layer_index, layer in enumerate(layers, 1):
+        req = urllib.request.Request(_blob_url(image_ref, layer["digest"]), headers=headers)
+        with urllib.request.urlopen(req, timeout=timeout) as response:
+            apply_tar_layer(response, layer["mediaType"], layer_index=layer_index, tree=tree)
+
+    return audit_entries(image, tree)

--- a/tests/test_cleanroom_audit.py
+++ b/tests/test_cleanroom_audit.py
@@ -1,0 +1,175 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import gzip
+import io
+import tarfile
+
+from typer.testing import CliRunner
+
+from programbench.cli.main import app
+from programbench.utils.cleanroom_audit import (
+    apply_tar_layers,
+    audit_entries,
+    parse_image_ref,
+)
+
+
+runner = CliRunner()
+
+
+def _layer(entries: list[tuple[str, bytes | None]]) -> io.BytesIO:
+    raw = io.BytesIO()
+    with tarfile.open(fileobj=raw, mode="w") as tar:
+        for name, content in entries:
+            info = tarfile.TarInfo(name)
+            if content is None:
+                info.type = tarfile.DIRTYPE
+                info.mode = 0o755
+                tar.addfile(info)
+            else:
+                info.size = len(content)
+                info.mode = 0o644
+                tar.addfile(info, io.BytesIO(content))
+
+    compressed = io.BytesIO()
+    with gzip.GzipFile(fileobj=compressed, mode="wb") as gz:
+        gz.write(raw.getvalue())
+    compressed.seek(0)
+    return compressed
+
+
+def test_audit_detects_doc_directory_whiteout() -> None:
+    base = _layer(
+        [
+            ("workspace/", None),
+            ("workspace/docs/", None),
+            ("workspace/docs/usage.md", b"usage"),
+            ("workspace/README.md", b"readme"),
+            ("workspace/LICENSE", b"license"),
+        ]
+    )
+    cleanroom = _layer([("workspace/.wh.docs", b"")])
+
+    tree = apply_tar_layers(
+        [
+            (base, "application/vnd.docker.image.rootfs.diff.tar.gzip"),
+            (cleanroom, "application/vnd.oci.image.layer.v1.tar+gzip"),
+        ]
+    )
+    audit = audit_entries("programbench/example:task_cleanroom", tree)
+
+    assert not audit.ok
+    assert audit.doc_entries == ()
+    assert audit.readme_entries == ("README.md",)
+    assert audit.license_entries == ("LICENSE",)
+    assert len(audit.doc_whiteouts) == 1
+    assert audit.doc_whiteouts[0].target == "workspace/docs"
+    assert audit.doc_whiteouts[0].removed_paths == 2
+
+
+def test_audit_passes_when_docs_remain() -> None:
+    base = _layer(
+        [
+            ("workspace/", None),
+            ("workspace/docs/", None),
+            ("workspace/docs/usage.md", b"usage"),
+            ("workspace/executable", b"#!/bin/sh\n"),
+        ]
+    )
+
+    tree = apply_tar_layers([(base, "application/vnd.docker.image.rootfs.diff.tar.gzip")])
+    audit = audit_entries("programbench/example:task_cleanroom", tree)
+
+    assert audit.ok
+    assert audit.doc_entries == ("docs/usage.md",)
+
+
+def test_audit_fails_for_empty_doc_directory() -> None:
+    base = _layer(
+        [
+            ("workspace/", None),
+            ("workspace/docs/", None),
+            ("workspace/executable", b"#!/bin/sh\n"),
+        ]
+    )
+
+    tree = apply_tar_layers([(base, "application/vnd.docker.image.rootfs.diff.tar.gzip")])
+    audit = audit_entries("programbench/example:task_cleanroom", tree)
+
+    assert not audit.ok
+    assert audit.doc_entries == ()
+
+
+def test_parse_image_ref_keeps_explicit_tag() -> None:
+    ref = parse_image_ref("programbench/zk-org_1776_zk.10d93d5:task_cleanroom")
+
+    assert ref.repository == "programbench/zk-org_1776_zk.10d93d5"
+    assert ref.tag == "task_cleanroom"
+
+
+def test_audit_cleanroom_docs_cli_reports_failure(monkeypatch) -> None:
+    seen_images = []
+
+    def fake_audit(image: str, *, timeout: float):
+        seen_images.append(image)
+        tree = apply_tar_layers(
+            [
+                (
+                    _layer(
+                        [
+                            ("workspace/", None),
+                            ("workspace/docs/", None),
+                            ("workspace/docs/usage.md", b"usage"),
+                            ("workspace/.wh.docs", b""),
+                        ]
+                    ),
+                    "application/vnd.docker.image.rootfs.diff.tar.gzip",
+                )
+            ]
+        )
+        return audit_entries(image, tree)
+
+    monkeypatch.setattr("programbench.utils.cleanroom_audit.audit_cleanroom_image", fake_audit)
+
+    result = runner.invoke(app, ["audit-cleanroom-docs", "programbench/example:task_cleanroom"])
+
+    assert result.exit_code == 1
+    assert seen_images == ["programbench/example:task_cleanroom"]
+    assert "missing-docs" in result.output
+    assert "doc whiteout" in result.output
+
+
+def test_audit_cleanroom_docs_cli_accepts_instance_ids(monkeypatch) -> None:
+    seen_images = []
+
+    def fake_audit(image: str, *, timeout: float):
+        seen_images.append(image)
+        tree = apply_tar_layers(
+            [
+                (
+                    _layer(
+                        [
+                            ("workspace/", None),
+                            ("workspace/docs/", None),
+                            ("workspace/docs/usage.md", b"usage"),
+                        ]
+                    ),
+                    "application/vnd.docker.image.rootfs.diff.tar.gzip",
+                )
+            ]
+        )
+        return audit_entries(image, tree)
+
+    monkeypatch.setattr("programbench.utils.cleanroom_audit.audit_cleanroom_image", fake_audit)
+
+    result = runner.invoke(app, ["audit-cleanroom-docs", "zk-org__zk.10d93d5"])
+
+    assert result.exit_code == 0
+    assert seen_images == ["programbench/zk-org_1776_zk.10d93d5:task_cleanroom"]
+    assert "ok" in result.output


### PR DESCRIPTION
## Summary
- add `programbench audit-cleanroom-docs` to audit cleanroom Docker images for real documentation files under `/workspace/doc`, `/workspace/docs`, or `/workspace/Documentation`
- reconstruct image filesystems directly from Docker registry layers and apply Docker whiteouts, so it can catch over-cleaning like `.wh.docs`
- allow either full image refs or ProgramBench instance IDs, e.g. `programbench audit-cleanroom-docs zk-org__zk.10d93d5`

## Reproduction
I reproduced #7 against the reported image, `programbench/zk-org_1776_zk.10d93d5:task_cleanroom`. The final cleanroom layer explicitly deletes `/workspace/docs`:

```text
programbench/zk-org_1776_zk.10d93d5:task_cleanroom: missing-docs
  documentation entries: 0
  README-like entries: README.md
  LICENSE-like entries: LICENSE
  doc whiteout: layer 16 workspace/.wh.docs removed workspace/docs (62 tracked paths)
```

## Verification
```text
env -u HTTP_PROXY -u HTTPS_PROXY -u http_proxy -u https_proxy uv run pytest
# 34 passed

env -u HTTP_PROXY -u HTTPS_PROXY -u http_proxy -u https_proxy uv run ruff check .
# All checks passed!

env -u HTTP_PROXY -u HTTPS_PROXY -u http_proxy -u https_proxy uv run ruff format --check .
# 21 files already formatted
```
