### PR TITLE
fix: align Go toolchain versions for tomnomnom__gron task images

### DIFF
--- a/src/programbench/data/tasks/tomnomnom__gron.88a6234/Dockerfile
+++ b/src/programbench/data/tasks/tomnomnom__gron.88a6234/Dockerfile
@@ -1,0 +1,1 @@
+FROM golang:1.21.0-alpine

--- a/src/programbench/data/tasks/tomnomnom__gron.88a6234/Dockerfile.cleanroom
+++ b/src/programbench/data/tasks/tomnomnom__gron.88a6234/Dockerfile.cleanroom
@@ -1,0 +1,1 @@
+FROM golang:1.21.0-alpine


### PR DESCRIPTION
Fixes #9
Both task and task_cleanroom images for tomnomnom__gron.88a6234 
were shipping with different Go versions:
  task_cleanroom → go1.21.0
  task                    → go1.24.2
This means a submission could be compiled against one toolchain 
and evaluated against another, making benchmark results unreliable.
Fix: pinned both Dockerfiles to golang:1.21.0-alpine to match the 
version declared in the project's go.mod.
Verified locally both containers now report the same Go version.