### PR TITLE
ci: declare workflow-level `contents: read` on 3 workflows

### DIFF
--- a/.github/workflows/check-links-periodic.yaml
+++ b/.github/workflows/check-links-periodic.yaml
@@ -10,6 +10,9 @@ on:
   schedule:
     - cron: "0 0,12 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   markdown-link-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-links-pr.yaml
+++ b/.github/workflows/check-links-pr.yaml
@@ -1,5 +1,9 @@
 on: [pull_request]
 name: Check Markdown links in modified files
+
+permissions:
+  contents: read
+
 jobs:
   markdown-link-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   pytest:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on 3 workflows in `.github/workflows/` that don't call a GitHub API beyond the initial checkout.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs. Pinning per workflow caps runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.