### PR TITLE
ci: use uv and test against Python 3.10 + 3.13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,19 +11,23 @@ permissions:
 jobs:
   pytest:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.13"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
-      - run: pip install -e ".[dev]" && pip install pytest
-      - run: pytest
+          python-version: ${{ matrix.python-version }}
+      - run: curl -LsSf https://astral.sh/uv/install.sh | sh
+      - run: uv sync
+      - run: uv run pytest
 
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
+          python-version: "3.13"
       - uses: pre-commit/action@v3.0.1


### PR DESCRIPTION
The test workflow used `pip install -e ".[dev]"`, but dev dependencies
live in a `[dependency-groups]` section (PEP 735) that pip does not
resolve — hence the extra `pip install pytest`. Switch to `uv sync` /
`uv run pytest`, matching the release workflow and CLAUDE.md quick
reference.

While here, add a version matrix (3.10 + 3.13) so CI covers both the
declared minimum (`requires-python = ">=3.10"`) and the version the
project actively develops on. Bump checkout/setup-python to v6 to match
release.yaml, and move pre-commit to 3.13.