### PR TITLE
Fix(eval): Ignore flaky and otherwise unsuitable tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,26 @@
 
 ProgramBench evaluates whether LM-based SWE-agents can reverse-engineer black-box software systems. The workflow: take an open-source CLI tool (mostly Rust/Go), compile it into a Docker image with source removed, then have an LM agent re-implement it from scratch by interacting only with the binary. Behavioral tests (also LM-generated) score the re-implementation.
 
+## Test ignore reasons
+
+Some behavioral tests are unreliable and are excluded from scoring. Each excluded
+test is recorded under `branches.<hash>.ignored_tests[]` in a task's `tests.json`,
+with one or more `reasons[].id` explaining why. All ignored tests are excluded from
+scoring regardless of reason; the id is informational.
+
+- `gold_fail` — test fails **deterministically** on the reference (gold) solution, so it
+  is defective rather than discriminating. Also covers golden-output drift (the gold
+  binary is correct but the captured golden is stale/non-reproducible relative to the
+  build toolchain, an embedded build-stamp, or an external resource).
+- `gold_flaky` — test is **non-deterministic** on the gold solution: it passes in some
+  runs and fails in others. These are timing/race/network/TUI-snapshot flakes, not real
+  defects (distinct from the deterministic `gold_fail`).
+- `dummy_pass` — test passes even on a trivial/dummy executable, so it fails to
+  distinguish a real implementation from a stub.
+- `outcome_dependent_presence` — test appears in some eval runs but not others.
+- `slow_or_hang` — test hangs mid-call or exceeds a duration threshold.
+- `ignored_manual` — manually excluded.
+
 ## Quick reference
 
 ```bash

--- a/src/programbench/data/tasks/antonmedv__walk.bf802ef/tests.json
+++ b/src/programbench/data/tasks/antonmedv__walk.bf802ef/tests.json
@@ -1165,6 +1165,42 @@
       ],
       "ignored_tests": [
         {
+          "name": "tests.test_cli_config.test_dir_only_flag_shows_only_directories",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Flaky TUI/listing output: an extra size line (e.g. '20B') appears nondeterministically",
+                "statuses": [
+                  "passed",
+                  "failure",
+                  "passed"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_cli_config.test_dir_only_with_icons_combines_both_features",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Flaky TUI/listing output: an extra size line (e.g. '20B') appears nondeterministically",
+                "statuses": [
+                  "passed",
+                  "failure",
+                  "passed"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_cli_config.test_empty_directory_shows_no_files_message",
           "reasons": [
             {
@@ -1185,10 +1221,136 @@
           ]
         },
         {
+          "name": "tests.test_cli_config.test_icons_flag_enables_icons",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Flaky TUI/listing output: an extra size line (e.g. '20B') appears nondeterministically",
+                "statuses": [
+                  "passed",
+                  "failure",
+                  "passed"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_cli_config.test_multiple_flags_together",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Flaky TUI/listing output: an extra size line (e.g. '20B') appears nondeterministically",
+                "statuses": [
+                  "passed",
+                  "failure",
+                  "passed"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_cli_config.test_path_argument_starts_in_specified_directory",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Flaky TUI/listing output: an extra size line (e.g. '20B') appears nondeterministically",
+                "statuses": [
+                  "passed",
+                  "failure",
+                  "passed"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_cli_config.test_path_argument_with_flags",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Flaky TUI/listing output: an extra size line (e.g. '20B') appears nondeterministically",
+                "statuses": [
+                  "passed",
+                  "failure",
+                  "passed"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_cli_config.test_preview_flag_enables_preview_mode",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Flaky TUI/listing output: an extra size line (e.g. '20B') appears nondeterministically",
+                "statuses": [
+                  "passed",
+                  "failure",
+                  "passed"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_cli_config.test_preview_mode_empty_directory",
           "reasons": [
             {
               "id": "gold_fail"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_cli_config.test_walk_main_color_env_changes_cursor_color",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Flaky TUI/listing output: an extra size line (e.g. '20B') appears nondeterministically",
+                "statuses": [
+                  "passed",
+                  "failure",
+                  "passed"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_cli_config.test_walk_no_highlight_env_disables_syntax_highlighting",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Flaky TUI/listing output: an extra size line (e.g. '20B') appears nondeterministically",
+                "statuses": [
+                  "passed",
+                  "failure",
+                  "passed"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
+              "user": "kilian"
             }
           ]
         },
@@ -1208,6 +1370,60 @@
             {
               "id": "gold_fail",
               "timestamp": 1777558221,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_edge_cases.test_empty_file_preview",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Flaky TUI/listing output: an extra size line (e.g. '20B') appears nondeterministically",
+                "statuses": [
+                  "passed",
+                  "failure",
+                  "passed"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_edge_cases.test_hidden_files_shown_by_default",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Flaky TUI/listing output: an extra size line (e.g. '20B') appears nondeterministically",
+                "statuses": [
+                  "passed",
+                  "failure",
+                  "passed"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_edge_cases.test_large_directory_500_files",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Flaky TUI/listing output: an extra size line (e.g. '20B') appears nondeterministically",
+                "statuses": [
+                  "passed",
+                  "failure",
+                  "passed"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
               "user": "kilian"
             }
           ]
@@ -1372,6 +1588,96 @@
             {
               "id": "gold_fail",
               "timestamp": 1777558221,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_edge_cases.test_special_characters_in_filenames",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Flaky TUI/listing output: an extra size line (e.g. '20B') appears nondeterministically",
+                "statuses": [
+                  "passed",
+                  "failure",
+                  "passed"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_edge_cases.test_symlinks_display_in_listing",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Flaky TUI/listing output: an extra size line (e.g. '20B') appears nondeterministically",
+                "statuses": [
+                  "passed",
+                  "failure",
+                  "passed"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_edge_cases.test_tab_character_in_filename",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Flaky TUI/listing output: an extra size line (e.g. '20B') appears nondeterministically",
+                "statuses": [
+                  "passed",
+                  "failure",
+                  "passed"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_edge_cases.test_unicode_filenames_display_correctly",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Flaky TUI/listing output: an extra size line (e.g. '20B') appears nondeterministically",
+                "statuses": [
+                  "passed",
+                  "failure",
+                  "passed"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_edge_cases.test_very_long_filenames_display",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Flaky TUI/listing output: an extra size line (e.g. '20B') appears nondeterministically",
+                "statuses": [
+                  "passed",
+                  "failure",
+                  "passed"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
               "user": "kilian"
             }
           ]
@@ -1601,10 +1907,424 @@
           ]
         },
         {
+          "name": "tests.test_icons.test_archive_extensions_show_zip_icon",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Flaky TUI/listing output: an extra size line (e.g. '20B') appears nondeterministically",
+                "statuses": [
+                  "passed",
+                  "failure",
+                  "passed"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_icons.test_files_without_extension_show_executable_or_generic_icon",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Flaky TUI/listing output: an extra size line (e.g. '20B') appears nondeterministically",
+                "statuses": [
+                  "passed",
+                  "failure",
+                  "passed"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_icons.test_hidden_files_still_show_extension_icons",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Flaky TUI/listing output: an extra size line (e.g. '20B') appears nondeterministically",
+                "statuses": [
+                  "passed",
+                  "failure",
+                  "passed"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_icons.test_icons_disabled_shows_no_icons",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Flaky TUI/listing output: an extra size line (e.g. '20B') appears nondeterministically",
+                "statuses": [
+                  "passed",
+                  "failure",
+                  "passed"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_icons.test_media_files_show_appropriate_icons",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Flaky TUI/listing output: an extra size line (e.g. '20B') appears nondeterministically",
+                "statuses": [
+                  "passed",
+                  "failure",
+                  "passed"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_icons.test_programming_language_extensions_show_correct_icons",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Flaky TUI/listing output: an extra size line (e.g. '20B') appears nondeterministically",
+                "statuses": [
+                  "passed",
+                  "failure",
+                  "passed"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_icons.test_specific_filenames_get_special_icons",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Flaky TUI/listing output: an extra size line (e.g. '20B') appears nondeterministically",
+                "statuses": [
+                  "passed",
+                  "failure",
+                  "passed"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_icons.test_unknown_extensions_show_generic_file_icon",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Flaky TUI/listing output: an extra size line (e.g. '20B') appears nondeterministically",
+                "statuses": [
+                  "passed",
+                  "failure",
+                  "passed"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_icons.test_uppercase_extensions_normalized_to_lowercase",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Flaky TUI/listing output: an extra size line (e.g. '20B') appears nondeterministically",
+                "statuses": [
+                  "passed",
+                  "failure",
+                  "passed"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_icons.test_wildcard_filename_patterns_match_correctly",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Flaky TUI/listing output: an extra size line (e.g. '20B') appears nondeterministically",
+                "statuses": [
+                  "passed",
+                  "failure",
+                  "passed"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_image_preview.test_animated_gif_renders_first_frame",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Flaky TUI/listing output: an extra size line (e.g. '20B') appears nondeterministically",
+                "statuses": [
+                  "passed",
+                  "failure",
+                  "passed"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_image_preview.test_corrupted_jpeg_shows_error",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Flaky TUI/listing output: an extra size line (e.g. '20B') appears nondeterministically",
+                "statuses": [
+                  "passed",
+                  "failure",
+                  "passed"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_image_preview.test_corrupted_png_shows_error",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Flaky TUI/listing output: an extra size line (e.g. '20B') appears nondeterministically",
+                "statuses": [
+                  "passed",
+                  "failure",
+                  "passed"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_image_preview.test_file_with_no_extension_not_treated_as_image",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Flaky TUI/listing output: an extra size line (e.g. '20B') appears nondeterministically",
+                "statuses": [
+                  "passed",
+                  "failure",
+                  "passed"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_image_preview.test_gif_with_mixed_case_extension",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Flaky TUI/listing output: an extra size line (e.g. '20B') appears nondeterministically",
+                "statuses": [
+                  "passed",
+                  "failure",
+                  "passed"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_image_preview.test_jpeg_with_uppercase_extension",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Flaky TUI/listing output: an extra size line (e.g. '20B') appears nondeterministically",
+                "statuses": [
+                  "passed",
+                  "failure",
+                  "passed"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_image_preview.test_png_image_preview",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Flaky TUI/listing output: an extra size line (e.g. '20B') appears nondeterministically",
+                "statuses": [
+                  "passed",
+                  "failure",
+                  "passed"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_image_preview.test_subdirectory_navigation_image_preview",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Flaky TUI/listing output: an extra size line (e.g. '20B') appears nondeterministically",
+                "statuses": [
+                  "passed",
+                  "failure",
+                  "passed"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_image_preview.test_symlink_to_image_renders",
           "reasons": [
             {
               "id": "gold_fail"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_image_preview.test_text_file_not_treated_as_image",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Flaky TUI/listing output: an extra size line (e.g. '20B') appears nondeterministically",
+                "statuses": [
+                  "passed",
+                  "failure",
+                  "passed"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_tui_navigation.test_backspace_exits_directory",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Flaky TUI/listing output: an extra size line (e.g. '20B') appears nondeterministically",
+                "statuses": [
+                  "passed",
+                  "failure",
+                  "passed"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_tui_navigation.test_initial_directory_listing",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Flaky TUI/listing output: an extra size line (e.g. '20B') appears nondeterministically",
+                "statuses": [
+                  "passed",
+                  "failure",
+                  "passed"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_tui_navigation.test_multicolumn_layout",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Flaky TUI/listing output: an extra size line (e.g. '20B') appears nondeterministically",
+                "statuses": [
+                  "passed",
+                  "failure",
+                  "passed"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_tui_navigation.test_toggle_hidden_files",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Flaky TUI/listing output: an extra size line (e.g. '20B') appears nondeterministically",
+                "statuses": [
+                  "passed",
+                  "failure",
+                  "passed"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
+              "user": "kilian"
             }
           ]
         },
@@ -1621,6 +2341,40 @@
           "reasons": [
             {
               "id": "gold_fail"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_tui_operations.test_multiple_delete_undo_cycles",
+          "reasons": [
+            {
+              "extra": {
+                "fail": 1,
+                "note": "TUI delete/undo temp-file existence race (filesystem state non-deterministic under tui2cli capture)",
+                "pass": 19,
+                "pattern": "ppppppppppfppppppppp",
+                "source": "20x gold cloud eval 2026-06-13"
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781326815,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_tui_operations.test_multiple_pending_deletions_stacked",
+          "reasons": [
+            {
+              "extra": {
+                "fail": 1,
+                "note": "TUI delete/undo temp-file existence race (filesystem state non-deterministic under tui2cli capture)",
+                "pass": 19,
+                "pattern": "ppppppppppfppppppppp",
+                "source": "20x gold cloud eval 2026-06-13"
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781326815,
+              "user": "kilian"
             }
           ]
         },

--- a/src/programbench/data/tasks/ast-grep__ast-grep.dde0fe0/tests.json
+++ b/src/programbench/data/tasks/ast-grep__ast-grep.dde0fe0/tests.json
@@ -982,11 +982,80 @@
           ]
         },
         {
+          "name": "eval.tests.test_language_features.test_mixed_js_and_css_injections_in_html",
+          "reasons": [
+            {
+              "extra": {
+                "fail": 1,
+                "note": "transient nondeterminism in HTML multi-language injection matching (passes 19/20)",
+                "pass": 19,
+                "pattern": "pfpppppppppppppppppp",
+                "source": "20x gold cloud eval 2026-06-13"
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781326815,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "eval.tests.test_language_features.test_mixed_typescript_and_javascript_in_html",
+          "reasons": [
+            {
+              "extra": {
+                "fail": 1,
+                "note": "transient nondeterminism in HTML multi-language injection matching (passes 19/20)",
+                "pass": 19,
+                "pattern": "ppppppppppppppfppppp",
+                "source": "20x gold cloud eval 2026-06-13"
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781326815,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "eval.tests.test_language_features.test_multiple_js_script_tags_in_html",
           "reasons": [
             {
               "id": "gold_fail",
               "timestamp": 1777558221,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "eval.tests.test_language_features.test_plain_js_script_not_matched_as_typescript",
+          "reasons": [
+            {
+              "extra": {
+                "fail": 1,
+                "note": "transient nondeterminism in HTML multi-language injection matching (passes 19/20)",
+                "pass": 19,
+                "pattern": "ppppppppppppppfppppp",
+                "source": "20x gold cloud eval 2026-06-13"
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781326815,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "eval.tests.test_language_features.test_typescript_type_alias_in_html",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Nondeterministic analysis/diagnostic ordering (parallel rule evaluation)",
+                "statuses": [
+                  "failure",
+                  "passed",
+                  "passed"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
               "user": "kilian"
             }
           ]
@@ -1007,6 +1076,24 @@
             {
               "id": "dummy_pass",
               "timestamp": 1777387538,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "eval.tests.test_parameterized_advanced.test_error_cyclic_dependency",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Nondeterministic analysis/diagnostic ordering (parallel rule evaluation)",
+                "statuses": [
+                  "failure",
+                  "passed",
+                  "passed"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
               "user": "kilian"
             }
           ]

--- a/src/programbench/data/tasks/bensadeh__tailspin.6278437/tests.json
+++ b/src/programbench/data/tasks/bensadeh__tailspin.6278437/tests.json
@@ -369,6 +369,17 @@
               "id": "dummy_pass"
             }
           ]
+        },
+        {
+          "name": "eval.tests.test_follow_mode.test_follow_flag_short",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
         }
       ]
     },

--- a/src/programbench/data/tasks/burntsushi__ripgrep.3b7fd44/tests.json
+++ b/src/programbench/data/tasks/burntsushi__ripgrep.3b7fd44/tests.json
@@ -5316,6 +5316,23 @@
       ],
       "ignored_tests": [
         {
+          "name": "tests.test_cli_utils.test_max_filesize_bytes_format",
+          "reasons": [
+            {
+              "extra": {
+                "fail": 1,
+                "note": "directory-listing order nondeterminism (large_file/small_file output order varies)",
+                "pass": 19,
+                "pattern": "pppfpppppppppppppppp",
+                "source": "20x gold cloud eval 2026-06-13"
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781326815,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_encoding.test_short_encoding_flag_syntax",
           "reasons": [
             {
@@ -6123,6 +6140,24 @@
             {
               "id": "dummy_pass",
               "timestamp": 1777387538,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_vimgrep.test_output_mode_no_heading_multifile",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Nondeterministic multifile output ordering (parallel directory walk)",
+                "statuses": [
+                  "passed",
+                  "failure",
+                  "passed"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
               "user": "kilian"
             }
           ]

--- a/src/programbench/data/tasks/canop__broot.d6c798e/tests.json
+++ b/src/programbench/data/tasks/canop__broot.d6c798e/tests.json
@@ -1353,6 +1353,17 @@
           ]
         },
         {
+          "name": "tests.test_panel_state.test_toggle_sizes_displays_file_sizes",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_panel_state.test_trash_panel_state",
           "reasons": [
             {

--- a/src/programbench/data/tasks/chirlu__sox.42b3557/tests.json
+++ b/src/programbench/data/tasks/chirlu__sox.42b3557/tests.json
@@ -1335,6 +1335,72 @@
           ]
         },
         {
+          "name": "tests.test_cli_options.test_buffer_option_missing_argument",
+          "reasons": [
+            {
+              "id": "gold_fail",
+              "note": "[gold_fail_v6_build_featureset] Fails on v6 gold: the reproducible build (e.g. ffmpeg --disable-autodetect) produces a deterministic but different optional-feature/codec/help-list set than the autodetect build the golden was captured against.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_cli_options.test_help_effect_nonexistent",
+          "reasons": [
+            {
+              "id": "gold_fail",
+              "note": "[gold_fail_v6_build_featureset] Fails on v6 gold: the reproducible build (e.g. ffmpeg --disable-autodetect) produces a deterministic but different optional-feature/codec/help-list set than the autodetect build the golden was captured against.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_cli_options.test_help_format_nonexistent",
+          "reasons": [
+            {
+              "id": "gold_fail",
+              "note": "[gold_fail_v6_build_featureset] Fails on v6 gold: the reproducible build (e.g. ffmpeg --disable-autodetect) produces a deterministic but different optional-feature/codec/help-list set than the autodetect build the golden was captured against.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_cli_options.test_help_output_complete",
+          "reasons": [
+            {
+              "id": "gold_fail",
+              "note": "[gold_fail_v6_build_featureset] Fails on v6 gold: the reproducible build (e.g. ffmpeg --disable-autodetect) produces a deterministic but different optional-feature/codec/help-list set than the autodetect build the golden was captured against.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_cli_options.test_invalid_option",
+          "reasons": [
+            {
+              "id": "gold_fail",
+              "note": "[gold_fail_v6_build_featureset] Fails on v6 gold: the reproducible build (e.g. ffmpeg --disable-autodetect) produces a deterministic but different optional-feature/codec/help-list set than the autodetect build the golden was captured against.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_cli_options.test_no_input_files",
+          "reasons": [
+            {
+              "id": "gold_fail",
+              "note": "[gold_fail_v6_build_featureset] Fails on v6 gold: the reproducible build (e.g. ffmpeg --disable-autodetect) produces a deterministic but different optional-feature/codec/help-list set than the autodetect build the golden was captured against.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_cli_options.test_reproducible_random",
           "reasons": [
             {

--- a/src/programbench/data/tasks/dandavison__delta.acd758f/tests.json
+++ b/src/programbench/data/tasks/dandavison__delta.acd758f/tests.json
@@ -1270,6 +1270,17 @@
           ]
         },
         {
+          "name": "tests.test_grep_gaps.test_git_grep_before_context_only",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_grep_gaps.test_git_grep_classic_output_type_override",
           "reasons": [
             {

--- a/src/programbench/data/tasks/duckdb__duckdb.bdb65ec/tests.json
+++ b/src/programbench/data/tasks/duckdb__duckdb.bdb65ec/tests.json
@@ -35228,6 +35228,23 @@
           ]
         },
         {
+          "name": "tests.test_harvest_sql_2.test_flatten",
+          "reasons": [
+            {
+              "extra": {
+                "fail": 1,
+                "note": "SQL result row-order nondeterminism (no ORDER BY): flatten rows reorder",
+                "pass": 19,
+                "pattern": "ppppppppppppppppppfp",
+                "source": "20x gold cloud eval 2026-06-13"
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781326815,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_harvest_sql_2.test_format_bytes",
           "reasons": [
             {

--- a/src/programbench/data/tasks/ekzhang__bore.8e059cd/tests.json
+++ b/src/programbench/data/tasks/ekzhang__bore.8e059cd/tests.json
@@ -529,6 +529,17 @@
               "id": "gold_fail"
             }
           ]
+        },
+        {
+          "name": "tests.test_harvest.test_basic_proxy[None]@server_tests",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
         }
       ]
     },

--- a/src/programbench/data/tasks/elkowar__pipr.fae0b17/tests.json
+++ b/src/programbench/data/tasks/elkowar__pipr.fae0b17/tests.json
@@ -2547,6 +2547,17 @@
           ]
         },
         {
+          "name": "tests.test_command_list_window.test_history_enter_selection",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_command_list_window.test_history_escape_closes_window",
           "reasons": [
             {

--- a/src/programbench/data/tasks/ffmpeg__ffmpeg.360a402/tests.json
+++ b/src/programbench/data/tasks/ffmpeg__ffmpeg.360a402/tests.json
@@ -3891,6 +3891,17 @@
           ]
         },
         {
+          "name": "tests.test_cmdutils_deep.test_list_encoders_complete",
+          "reasons": [
+            {
+              "id": "gold_fail",
+              "note": "[gold_fail_v6_build_featureset] Fails on v6 gold: the reproducible build (e.g. ffmpeg --disable-autodetect) produces a deterministic but different optional-feature/codec/help-list set than the autodetect build the golden was captured against.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_cmdutils_gaps.test_codecs_list_complete",
           "reasons": [
             {
@@ -12454,6 +12465,50 @@
           ]
         },
         {
+          "name": "tests.test_help_info.test_codecs",
+          "reasons": [
+            {
+              "id": "gold_fail",
+              "note": "[gold_fail_v6_build_featureset] Fails on v6 gold: the reproducible build (e.g. ffmpeg --disable-autodetect) produces a deterministic but different optional-feature/codec/help-list set than the autodetect build the golden was captured against.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_help_info.test_decoders",
+          "reasons": [
+            {
+              "id": "gold_fail",
+              "note": "[gold_fail_v6_build_featureset] Fails on v6 gold: the reproducible build (e.g. ffmpeg --disable-autodetect) produces a deterministic but different optional-feature/codec/help-list set than the autodetect build the golden was captured against.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_help_info.test_encoders",
+          "reasons": [
+            {
+              "id": "gold_fail",
+              "note": "[gold_fail_v6_build_featureset] Fails on v6 gold: the reproducible build (e.g. ffmpeg --disable-autodetect) produces a deterministic but different optional-feature/codec/help-list set than the autodetect build the golden was captured against.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_help_info.test_help_full",
+          "reasons": [
+            {
+              "id": "gold_fail",
+              "note": "[gold_fail_v6_build_featureset] Fails on v6 gold: the reproducible build (e.g. ffmpeg --disable-autodetect) produces a deterministic but different optional-feature/codec/help-list set than the autodetect build the golden was captured against.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_logging.test_default_help_shows_banner",
           "reasons": [
             {
@@ -12566,6 +12621,39 @@
           ]
         },
         {
+          "name": "tests.test_opt_common_final.test_show_codecs_list",
+          "reasons": [
+            {
+              "id": "gold_fail",
+              "note": "[gold_fail_v6_build_featureset] Fails on v6 gold: the reproducible build (e.g. ffmpeg --disable-autodetect) produces a deterministic but different optional-feature/codec/help-list set than the autodetect build the golden was captured against.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_opt_common_final.test_show_decoders_list",
+          "reasons": [
+            {
+              "id": "gold_fail",
+              "note": "[gold_fail_v6_build_featureset] Fails on v6 gold: the reproducible build (e.g. ffmpeg --disable-autodetect) produces a deterministic but different optional-feature/codec/help-list set than the autodetect build the golden was captured against.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_opt_common_final.test_show_encoders_list",
+          "reasons": [
+            {
+              "id": "gold_fail",
+              "note": "[gold_fail_v6_build_featureset] Fails on v6 gold: the reproducible build (e.g. ffmpeg --disable-autodetect) produces a deterministic but different optional-feature/codec/help-list set than the autodetect build the golden was captured against.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_option_parsing.test_noautorotate_boolean_negation",
           "reasons": [
             {
@@ -12581,6 +12669,23 @@
             {
               "id": "dummy_pass",
               "timestamp": 1777387540,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_textformat_gaps.test_default_format_noprint_wrappers_option",
+          "reasons": [
+            {
+              "extra": {
+                "fail": 1,
+                "note": "test-resource setup race: input.mp4 not present yet when test runs under pytest-xdist",
+                "pass": 19,
+                "pattern": "ppppfppppppppppppppp",
+                "source": "20x gold cloud eval 2026-06-13"
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781326815,
               "user": "kilian"
             }
           ]

--- a/src/programbench/data/tasks/gromacs__gromacs.665ea4c/tests.json
+++ b/src/programbench/data/tasks/gromacs__gromacs.665ea4c/tests.json
@@ -2315,6 +2315,127 @@
           ]
         },
         {
+          "name": "tests.test_structure.test_gyrate_protein_basic",
+          "reasons": [
+            {
+              "id": "gold_fail",
+              "note": "[gold_fail_v6_build_stamp] Fails on v6 gold: test asserts a build-stamped version/commit/date string (non-reproducible build metadata, e.g. embedded git rev or build date) rather than functionality; the golden captured the previous build's stamp.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_structure.test_gyrate_weighting_modes",
+          "reasons": [
+            {
+              "id": "gold_fail",
+              "note": "[gold_fail_v6_build_stamp] Fails on v6 gold: test asserts a build-stamped version/commit/date string (non-reproducible build metadata, e.g. embedded git rev or build date) rather than functionality; the golden captured the previous build's stamp.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_structure.test_rms_backbone",
+          "reasons": [
+            {
+              "id": "gold_fail",
+              "note": "[gold_fail_v6_build_stamp] Fails on v6 gold: test asserts a build-stamped version/commit/date string (non-reproducible build metadata, e.g. embedded git rev or build date) rather than functionality; the golden captured the previous build's stamp.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_structure.test_rms_calpha_basic",
+          "reasons": [
+            {
+              "id": "gold_fail",
+              "note": "[gold_fail_v6_build_stamp] Fails on v6 gold: test asserts a build-stamped version/commit/date string (non-reproducible build metadata, e.g. embedded git rev or build date) rather than functionality; the golden captured the previous build's stamp.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_structure.test_rms_fit_translation",
+          "reasons": [
+            {
+              "id": "gold_fail",
+              "note": "[gold_fail_v6_build_stamp] Fails on v6 gold: test asserts a build-stamped version/commit/date string (non-reproducible build metadata, e.g. embedded git rev or build date) rather than functionality; the golden captured the previous build's stamp.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_structure.test_rms_mirror_image",
+          "reasons": [
+            {
+              "id": "gold_fail",
+              "note": "[gold_fail_v6_build_stamp] Fails on v6 gold: test asserts a build-stamped version/commit/date string (non-reproducible build metadata, e.g. embedded git rev or build date) rather than functionality; the golden captured the previous build's stamp.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_structure.test_rms_nofit",
+          "reasons": [
+            {
+              "id": "gold_fail",
+              "note": "[gold_fail_v6_build_stamp] Fails on v6 gold: test asserts a build-stamped version/commit/date string (non-reproducible build metadata, e.g. embedded git rev or build date) rather than functionality; the golden captured the previous build's stamp.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_structure.test_rms_time_range",
+          "reasons": [
+            {
+              "id": "gold_fail",
+              "note": "[gold_fail_v6_build_stamp] Fails on v6 gold: test asserts a build-stamped version/commit/date string (non-reproducible build metadata, e.g. embedded git rev or build date) rather than functionality; the golden captured the previous build's stamp.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_structure.test_rms_what_rho",
+          "reasons": [
+            {
+              "id": "gold_fail",
+              "note": "[gold_fail_v6_build_stamp] Fails on v6 gold: test asserts a build-stamped version/commit/date string (non-reproducible build metadata, e.g. embedded git rev or build date) rather than functionality; the golden captured the previous build's stamp.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_structure.test_rmsf_calpha_basic",
+          "reasons": [
+            {
+              "id": "gold_fail",
+              "note": "[gold_fail_v6_build_stamp] Fails on v6 gold: test asserts a build-stamped version/commit/date string (non-reproducible build metadata, e.g. embedded git rev or build date) rather than functionality; the golden captured the previous build's stamp.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_structure.test_rmsf_residue_averaging",
+          "reasons": [
+            {
+              "id": "gold_fail",
+              "note": "[gold_fail_v6_build_stamp] Fails on v6 gold: test asserts a build-stamped version/commit/date string (non-reproducible build metadata, e.g. embedded git rev or build date) rather than functionality; the golden captured the previous build's stamp.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_tcaf_trjorder.test_tcaf_cubic_averaging_optional",
           "reasons": [
             {

--- a/src/programbench/data/tasks/hatoo__oha.8dc6349/tests.json
+++ b/src/programbench/data/tasks/hatoo__oha.8dc6349/tests.json
@@ -1816,6 +1816,28 @@
           ]
         },
         {
+          "name": "tests.test_output.test_json_output_details_connection_time_relationships",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_output.test_json_output_details_connection_times",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_output.test_json_output_error_distribution_empty_on_success",
           "reasons": [
             {
@@ -1858,6 +1880,17 @@
           ]
         },
         {
+          "name": "tests.test_output.test_json_output_status_code_distribution",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_output.test_json_output_with_higher_request_count",
           "reasons": [
             {
@@ -1870,6 +1903,17 @@
           "reasons": [
             {
               "id": "gold_fail"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_output.test_json_output_with_single_connection",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
             }
           ]
         },
@@ -2106,6 +2150,17 @@
           ]
         },
         {
+          "name": "tests.test_timescale.test_time_unit_precision_formatting",
+          "reasons": [
+            {
+              "id": "gold_fail",
+              "note": "[gold_fail_v6_toolchain] Summary emits fewer 4-decimal time values than the golden expects (oha output-format/version drift). 20x gold cloud eval 2026-06-13, failed 20/20 rounds",
+              "timestamp": 1781487387,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_timescale.test_time_unit_seconds_text_output",
           "reasons": [
             {
@@ -2244,11 +2299,47 @@
           ]
         },
         {
+          "name": "tests.test_tui.test_tui_multiple_status_codes",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Flaky TUI render timing (live progress / HTTP-load output)",
+                "statuses": [
+                  "failure",
+                  "passed",
+                  "passed"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_tui.test_tui_with_high_concurrency",
           "reasons": [
             {
               "id": "gold_fail",
               "timestamp": 1777816048,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_tui.test_tui_with_post_method",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Flaky TUI render timing (live progress / HTTP-load output)",
+                "statuses": [
+                  "failure",
+                  "passed",
+                  "passed"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
               "user": "kilian"
             }
           ]

--- a/src/programbench/data/tasks/htop-dev__htop.523600b/tests.json
+++ b/src/programbench/data/tasks/htop-dev__htop.523600b/tests.json
@@ -5185,6 +5185,17 @@
           ]
         },
         {
+          "name": "eval.tests.test_ultra_intensive.test_ultra_tree_all_configs",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "eval.tests.test_update_control.test_delay_flag",
           "reasons": [
             {

--- a/src/programbench/data/tasks/isona__dirble.e2dea9f/tests.json
+++ b/src/programbench/data/tasks/isona__dirble.e2dea9f/tests.json
@@ -2461,6 +2461,24 @@
       ],
       "ignored_tests": [
         {
+          "name": "tests.test_edge_cases.test_uri_file_with_mixed_valid_invalid_urls",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Network-dependent (external HTTP/proxy, e.g. httpbin / ipv6 localhost)",
+                "statuses": [
+                  "passed",
+                  "failure",
+                  "passed"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_edge_cases.test_url_with_encoded_spaces",
           "reasons": [
             {
@@ -3321,6 +3339,23 @@
           ]
         },
         {
+          "name": "tests.test_output_formats.test_default_text_output_format",
+          "reasons": [
+            {
+              "extra": {
+                "fail": 1,
+                "note": "local HTTP test-server connection race (curl: Could not connect to 127.0.0.1:8765)",
+                "pass": 19,
+                "pattern": "ppppppppppppppppfppp",
+                "source": "20x gold cloud eval 2026-06-13"
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781326815,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_output_formats.test_hide_lengths_affects_all_output_formats",
           "reasons": [
             {
@@ -3396,6 +3431,23 @@
             {
               "id": "gold_fail",
               "timestamp": 1777386527,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_output_formats.test_show_htaccess_flag",
+          "reasons": [
+            {
+              "extra": {
+                "fail": 2,
+                "note": "local HTTP test-server connection race (curl: Could not connect to 127.0.0.1:8765)",
+                "pass": 18,
+                "pattern": "pppppppppppppfppfppp",
+                "source": "20x gold cloud eval 2026-06-13"
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781326815,
               "user": "kilian"
             }
           ]

--- a/src/programbench/data/tasks/jgm__pandoc.5caad90/tests.json
+++ b/src/programbench/data/tasks/jgm__pandoc.5caad90/tests.json
@@ -5530,6 +5530,39 @@
       ],
       "ignored_tests": [
         {
+          "name": "tests.test_asciidoc_rst_typst.test_asciidoc_attributes_and_metadata",
+          "reasons": [
+            {
+              "id": "gold_fail",
+              "note": "[gold_fail_v6_toolchain] Gold emits pandoc-api-version [1,23,1,2]; goldens captured against [1,23,1,1] (pandoc-types library version drift in the reproducible build). 20x gold cloud eval 2026-06-13, failed 20/20 rounds",
+              "timestamp": 1781487387,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_asciidoc_rst_typst.test_rst_to_json_ast_structure",
+          "reasons": [
+            {
+              "id": "gold_fail",
+              "note": "[gold_fail_v6_toolchain] Gold emits pandoc-api-version [1,23,1,2]; goldens captured against [1,23,1,1] (pandoc-types library version drift in the reproducible build). 20x gold cloud eval 2026-06-13, failed 20/20 rounds",
+              "timestamp": 1781487387,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_asciidoc_rst_typst.test_typst_metadata_extraction",
+          "reasons": [
+            {
+              "id": "gold_fail",
+              "note": "[gold_fail_v6_toolchain] Gold emits pandoc-api-version [1,23,1,2]; goldens captured against [1,23,1,1] (pandoc-types library version drift in the reproducible build). 20x gold cloud eval 2026-06-13, failed 20/20 rounds",
+              "timestamp": 1781487387,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_citations.test_bibliography_entry_ids",
           "reasons": [
             {
@@ -5690,11 +5723,33 @@
           ]
         },
         {
+          "name": "tests.test_encoding_i18n.test_unicode_preservation_in_json_format",
+          "reasons": [
+            {
+              "id": "gold_fail",
+              "note": "[gold_fail_v6_toolchain] Gold emits pandoc-api-version [1,23,1,2]; goldens captured against [1,23,1,1] (pandoc-types library version drift in the reproducible build). 20x gold cloud eval 2026-06-13, failed 20/20 rounds",
+              "timestamp": 1781487387,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_error_handling.test_medium_large_file_processing",
           "reasons": [
             {
               "id": "gold_fail",
               "timestamp": 1777386527,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_error_paths.test_json_incompatible_api_version",
+          "reasons": [
+            {
+              "id": "gold_fail",
+              "note": "[gold_fail_v6_toolchain] Gold emits pandoc-api-version [1,23,1,2]; goldens captured against [1,23,1,1] (pandoc-types library version drift in the reproducible build). 20x gold cloud eval 2026-06-13, failed 20/20 rounds",
+              "timestamp": 1781487387,
               "user": "kilian"
             }
           ]
@@ -5720,11 +5775,55 @@
           ]
         },
         {
+          "name": "tests.test_filesystem_ops.test_output_json_format_produces_parseable_json",
+          "reasons": [
+            {
+              "id": "gold_fail",
+              "note": "[gold_fail_v6_toolchain] Gold emits pandoc-api-version [1,23,1,2]; goldens captured against [1,23,1,1] (pandoc-types library version drift in the reproducible build). 20x gold cloud eval 2026-06-13, failed 20/20 rounds",
+              "timestamp": 1781487387,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_filesystem_ops.test_output_same_as_input_file_handles_atomicity",
           "reasons": [
             {
               "id": "dummy_pass",
               "timestamp": 1777387541,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_filters_ast_advanced.test_filter_complex_metadata_structure",
+          "reasons": [
+            {
+              "id": "gold_fail",
+              "note": "[gold_fail_v6_toolchain] Gold emits pandoc-api-version [1,23,1,2]; goldens captured against [1,23,1,1] (pandoc-types library version drift in the reproducible build). 20x gold cloud eval 2026-06-13, failed 20/20 rounds",
+              "timestamp": 1781487387,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_filters_ast_advanced.test_json_ast_filter_transformation",
+          "reasons": [
+            {
+              "id": "gold_fail",
+              "note": "[gold_fail_v6_toolchain] Gold emits pandoc-api-version [1,23,1,2]; goldens captured against [1,23,1,1] (pandoc-types library version drift in the reproducible build). 20x gold cloud eval 2026-06-13, failed 20/20 rounds",
+              "timestamp": 1781487387,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_format_matrix.test_markdown_to_json_ast_lossless_machine_readable",
+          "reasons": [
+            {
+              "id": "gold_fail",
+              "note": "[gold_fail_v6_toolchain] Gold emits pandoc-api-version [1,23,1,2]; goldens captured against [1,23,1,1] (pandoc-types library version drift in the reproducible build). 20x gold cloud eval 2026-06-13, failed 20/20 rounds",
+              "timestamp": 1781487387,
               "user": "kilian"
             }
           ]
@@ -7405,6 +7504,28 @@
           ]
         },
         {
+          "name": "tests.test_man_format.test_man_only_title_header",
+          "reasons": [
+            {
+              "id": "gold_fail",
+              "note": "[gold_fail_v6_toolchain] Gold emits pandoc-api-version [1,23,1,2]; goldens captured against [1,23,1,1] (pandoc-types library version drift in the reproducible build). 20x gold cloud eval 2026-06-13, failed 20/20 rounds",
+              "timestamp": 1781487387,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_man_format.test_man_to_json_ast",
+          "reasons": [
+            {
+              "id": "gold_fail",
+              "note": "[gold_fail_v6_toolchain] Gold emits pandoc-api-version [1,23,1,2]; goldens captured against [1,23,1,1] (pandoc-types library version drift in the reproducible build). 20x gold cloud eval 2026-06-13, failed 20/20 rounds",
+              "timestamp": 1781487387,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_markdown_headings_lists.test_markdown_headings_roundtrip_atx",
           "reasons": [
             {
@@ -7420,6 +7541,17 @@
             {
               "id": "dummy_pass",
               "timestamp": 1777387541,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_org_opml_pod.test_pod_to_json_ast",
+          "reasons": [
+            {
+              "id": "gold_fail",
+              "note": "[gold_fail_v6_toolchain] Gold emits pandoc-api-version [1,23,1,2]; goldens captured against [1,23,1,1] (pandoc-types library version drift in the reproducible build). 20x gold cloud eval 2026-06-13, failed 20/20 rounds",
+              "timestamp": 1781487387,
               "user": "kilian"
             }
           ]
@@ -7474,6 +7606,17 @@
             {
               "id": "dummy_pass",
               "timestamp": 1777387541,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_rtf_advanced.test_rtf_to_json_ast_structure",
+          "reasons": [
+            {
+              "id": "gold_fail",
+              "note": "[gold_fail_v6_toolchain] Gold emits pandoc-api-version [1,23,1,2]; goldens captured against [1,23,1,1] (pandoc-types library version drift in the reproducible build). 20x gold cloud eval 2026-06-13, failed 20/20 rounds",
+              "timestamp": 1781487387,
               "user": "kilian"
             }
           ]
@@ -7668,6 +7811,17 @@
             {
               "id": "dummy_pass",
               "timestamp": 1777387541,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_tsv_tables.test_tsv_to_json_ast",
+          "reasons": [
+            {
+              "id": "gold_fail",
+              "note": "[gold_fail_v6_toolchain] Gold emits pandoc-api-version [1,23,1,2]; goldens captured against [1,23,1,1] (pandoc-types library version drift in the reproducible build). 20x gold cloud eval 2026-06-13, failed 20/20 rounds",
+              "timestamp": 1781487387,
               "user": "kilian"
             }
           ]

--- a/src/programbench/data/tasks/jrnxf__thokr.09375ef/tests.json
+++ b/src/programbench/data/tasks/jrnxf__thokr.09375ef/tests.json
@@ -557,6 +557,24 @@
           ]
         },
         {
+          "name": "tests.test_logging.test_timed_test_num_secs_has_value",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Timing-dependent (elapsed-time assertion)",
+                "statuses": [
+                  "passed",
+                  "passed",
+                  "failure"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_tui_basic.test_ctrl_c_exits",
           "reasons": [
             {
@@ -567,11 +585,73 @@
           ]
         },
         {
+          "name": "tests.test_tui_timed.test_timer_display_format",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_tui_timed.test_timer_not_shown_without_s_flag",
+          "reasons": [
+            {
+              "extra": {
+                "fail": 1,
+                "note": "TUI timer rendering timing race (running/paused timer state non-deterministic in captured frame)",
+                "pass": 19,
+                "pattern": "pfpppppppppppppppppp",
+                "source": "20x gold cloud eval 2026-06-13"
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781326815,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_tui_timed.test_timer_pauses_on_results_screen",
+          "reasons": [
+            {
+              "extra": {
+                "fail": 13,
+                "note": "TUI timer rendering timing race (running/paused timer state non-deterministic in captured frame)",
+                "pass": 7,
+                "pattern": "ppffffffppfppffffffp",
+                "source": "20x gold cloud eval 2026-06-13"
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781326815,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_tui_timed.test_timer_with_3_seconds",
           "reasons": [
             {
               "id": "gold_fail",
               "timestamp": 1777386528,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_tui_timed.test_timer_with_5_seconds",
+          "reasons": [
+            {
+              "extra": {
+                "fail": 5,
+                "note": "TUI timer rendering timing race (running/paused timer state non-deterministic in captured frame)",
+                "pass": 15,
+                "pattern": "fffpppppppfppppppfpp",
+                "source": "20x gold cloud eval 2026-06-13"
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781326815,
               "user": "kilian"
             }
           ]

--- a/src/programbench/data/tasks/junegunn__fzf.b56d614/tests.json
+++ b/src/programbench/data/tasks/junegunn__fzf.b56d614/tests.json
@@ -4645,6 +4645,17 @@
       ],
       "ignored_tests": [
         {
+          "name": "tests.test_fzf.TestBasicFunctionality.test_version_flag",
+          "reasons": [
+            {
+              "id": "gold_fail",
+              "note": "[gold_fail_v6_build_stamp] Fails on v6 gold: test asserts a build-stamped version/commit/date string (non-reproducible build metadata, e.g. embedded git rev or build date) rather than functionality; the golden captured the previous build's stamp.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_fzf.TestCommandLineParsing.test_short_and_long_flags",
           "reasons": [
             {
@@ -4703,6 +4714,17 @@
         "eval.tests.test_fzf_interactive_tmux.test_interactive_expect_ctrl_j_prints_key_then_selection"
       ],
       "ignored_tests": [
+        {
+          "name": "eval.tests.test_fzf_cli.test_version_exact",
+          "reasons": [
+            {
+              "id": "gold_fail",
+              "note": "[gold_fail_v6_build_stamp] Fails on v6 gold: test asserts a build-stamped version/commit/date string (non-reproducible build metadata, e.g. embedded git rev or build date) rather than functionality; the golden captured the previous build's stamp.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
         {
           "name": "eval.tests.test_fzf_interactive_tmux.test_interactive_expect_ctrl_j_prints_key_then_selection",
           "reasons": [

--- a/src/programbench/data/tasks/kisielk__errcheck.dacab89/tests.json
+++ b/src/programbench/data/tasks/kisielk__errcheck.dacab89/tests.json
@@ -1374,6 +1374,17 @@
           ]
         },
         {
+          "name": "tests.test_output.test_exit_code_two_on_fatal_errors",
+          "reasons": [
+            {
+              "id": "gold_fail",
+              "note": "[gold_fail_v6_toolchain] Fails on v6 gold: output reflects the pinned toolchain / dependency versions (e.g. Go compiler diagnostic wording, stdlib net behavior, or generated-code content); the golden captured the previous build environment's output.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_smoke.test_no_args_runs",
           "reasons": [
             {

--- a/src/programbench/data/tasks/kyoheiu__felix.95df390/tests.json
+++ b/src/programbench/data/tasks/kyoheiu__felix.95df390/tests.json
@@ -2838,6 +2838,17 @@
           ]
         },
         {
+          "name": "tests.test_layout_calculations.test_narrow_terminal_below_proper_width",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_magic_packed_extended.test_unpack_plain_text_non_archive_error",
           "reasons": [
             {

--- a/src/programbench/data/tasks/mkj__dropbear.75f699b/tests.json
+++ b/src/programbench/data/tasks/mkj__dropbear.75f699b/tests.json
@@ -1652,11 +1652,39 @@
           ]
         },
         {
+          "name": "tests.test_authkey_options_gap.test_malformed_permitopen_non_numeric_port",
+          "reasons": [
+            {
+              "extra": {
+                "fail": 12,
+                "note": "ssh dbclient connection/host-key-mismatch/socket-bind race (regenerated host keys + port reuse under xdist)",
+                "pass": 8,
+                "pattern": "pffppffpppffffpffpff",
+                "source": "20x gold cloud eval 2026-06-13"
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781326815,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_authkey_options_gap.test_multiple_command_options_rejected",
           "reasons": [
             {
               "id": "gold_fail",
               "timestamp": 1777386528,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_authkey_options_gap.test_option_case_insensitive",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "ssh dbclient connection/host-key-mismatch race (same family as other dropbear flakes). caught in postfix gold rerun (21st run); passed 20/20 in 20x sweep",
+              "timestamp": 1781500166,
               "user": "kilian"
             }
           ]
@@ -2022,11 +2050,64 @@
           ]
         },
         {
+          "name": "tests.test_forwarding_x11_agent.test_agent_socket_actually_exists",
+          "reasons": [
+            {
+              "extra": {
+                "fail": 1,
+                "note": "ssh dbclient connection/host-key-mismatch/socket-bind race (regenerated host keys + port reuse under xdist)",
+                "pass": 19,
+                "pattern": "pppppppppppppfpppppp",
+                "source": "20x gold cloud eval 2026-06-13"
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781326815,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_forwarding_x11_agent.test_agent_socket_cleanup_on_disconnect",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "SSH socket/port/host-key race (random ports, key mismatch)",
+                "statuses": [
+                  "passed",
+                  "failure",
+                  "passed"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_forwarding_x11_agent.test_agent_socket_directory_permissions",
           "reasons": [
             {
               "id": "gold_fail",
               "timestamp": 1777558222,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_forwarding_x11_agent.test_agent_socket_fd_number_in_filename",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "SSH socket/port/host-key race (random ports, key mismatch)",
+                "statuses": [
+                  "passed",
+                  "failure",
+                  "passed"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
               "user": "kilian"
             }
           ]
@@ -2042,11 +2123,39 @@
           ]
         },
         {
+          "name": "tests.test_forwarding_x11_agent.test_agent_socket_path_format",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_forwarding_x11_agent.test_agent_socket_permissions",
           "reasons": [
             {
               "id": "gold_fail",
               "timestamp": 1777558222,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_forwarding_x11_agent.test_agent_socket_random_components",
+          "reasons": [
+            {
+              "extra": {
+                "fail": 3,
+                "note": "ssh dbclient connection/host-key-mismatch/socket-bind race (regenerated host keys + port reuse under xdist)",
+                "pass": 17,
+                "pattern": "fpppfpppppppfppppppp",
+                "source": "20x gold cloud eval 2026-06-13"
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781326815,
               "user": "kilian"
             }
           ]
@@ -3142,6 +3251,24 @@
           ]
         },
         {
+          "name": "tests.test_netio_gap.test_client_connection_to_ipv4_only_server",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "SSH socket/port/host-key race (random ports, key mismatch)",
+                "statuses": [
+                  "passed",
+                  "passed",
+                  "failure"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_netio_gap.test_client_ipv4_mapped_connection",
           "reasons": [
             {
@@ -3372,6 +3499,23 @@
           ]
         },
         {
+          "name": "tests.test_pty_terminal.test_pty_newline_handling",
+          "reasons": [
+            {
+              "extra": {
+                "fail": 1,
+                "note": "ssh dbclient connection/host-key-mismatch/socket-bind race (regenerated host keys + port reuse under xdist)",
+                "pass": 19,
+                "pattern": "ppppppfppppppppppppp",
+                "source": "20x gold cloud eval 2026-06-13"
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781326815,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_pty_terminal.test_pty_not_allocated_without_t_flag",
           "reasons": [
             {
@@ -3387,6 +3531,23 @@
             {
               "id": "gold_fail",
               "timestamp": 1777558222,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_pty_terminal.test_pty_read_large_output",
+          "reasons": [
+            {
+              "extra": {
+                "fail": 1,
+                "note": "ssh dbclient connection/host-key-mismatch/socket-bind race (regenerated host keys + port reuse under xdist)",
+                "pass": 19,
+                "pattern": "fppppppppppppppppppp",
+                "source": "20x gold cloud eval 2026-06-13"
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781326815,
               "user": "kilian"
             }
           ]
@@ -3507,6 +3668,24 @@
             {
               "id": "gold_fail",
               "timestamp": 1777386528,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_pubkey_auth.test_crlf_line_endings",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "SSH socket/port/host-key race (random ports, key mismatch)",
+                "statuses": [
+                  "failure",
+                  "passed",
+                  "failure"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
               "user": "kilian"
             }
           ]
@@ -4643,6 +4822,19 @@
             },
             {
               "id": "dummy_pass"
+            },
+            {
+              "extra": {
+                "cause": "SSH socket/port/host-key race (random ports, key mismatch)",
+                "statuses": [
+                  "failure",
+                  "passed",
+                  "failure"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
+              "user": "kilian"
             }
           ]
         },

--- a/src/programbench/data/tasks/nikolassv__bartib.6b9b5ce/tests.json
+++ b/src/programbench/data/tasks/nikolassv__bartib.6b9b5ce/tests.json
@@ -1136,6 +1136,17 @@
           ]
         },
         {
+          "name": "tests.test_current_status.test_current_special_characters_in_names",
+          "reasons": [
+            {
+              "id": "gold_fail",
+              "note": "[gold_fail_v6_toolchain] Table header trailing-whitespace differs by one space from golden (formatter version drift). 20x gold cloud eval 2026-06-13, failed 20/20 rounds",
+              "timestamp": 1781487387,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_current_status.test_status_aggregation_multiple_same_project",
           "reasons": [
             {

--- a/src/programbench/data/tasks/noborus__ov.b96c2ba/tests.json
+++ b/src/programbench/data/tasks/noborus__ov.b96c2ba/tests.json
@@ -5452,11 +5452,33 @@
           ]
         },
         {
+          "name": "tests.test_edit.test_editor_line_number_placeholder",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_edit.test_temp_file_cleanup_after_edit",
           "reasons": [
             {
               "id": "dummy_pass",
               "timestamp": 1777387546,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_exec_mode.test_exec_mode_command_error_captured_in_stderr",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
               "user": "kilian"
             }
           ]
@@ -5477,6 +5499,17 @@
             {
               "id": "dummy_pass",
               "timestamp": 1777387546,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_filter_search_advanced.test_invalid_regex_fallback_to_literal",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
               "user": "kilian"
             }
           ]
@@ -5510,10 +5543,54 @@
           ]
         },
         {
+          "name": "tests.test_input_header_modes.test_header_column_accepts_numeric_value",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_input_header_modes.test_header_input_empty_string_shows_error",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_input_header_modes.test_header_input_invalid_characters",
           "reasons": [
             {
               "id": "gold_fail"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_input_header_modes.test_header_input_mode_prompt_appears",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_input_header_modes.test_header_input_multiple_digits",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
             }
           ]
         },
@@ -5528,11 +5605,77 @@
           ]
         },
         {
+          "name": "tests.test_input_header_modes.test_jump_target_input_mode_prompt_appears",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_input_header_modes.test_jump_target_numeric_value",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_input_modes_advanced.test_filter_mode_up_populates_from_history",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_input_modes_advanced.test_multicolor_confirm_sets_multicolor",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_input_modes_advanced.test_multicolor_up_down_navigation",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_mouse_marks_sidebar.test_mark_multiple_lines_and_navigate",
           "reasons": [
             {
               "id": "gold_fail",
               "timestamp": 1777386529,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_mouse_marks_sidebar.test_mark_single_line",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
               "user": "kilian"
             }
           ]
@@ -5556,10 +5699,76 @@
           ]
         },
         {
+          "name": "tests.test_mouse_marks_sidebar.test_sidebar_document_list",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_mouse_marks_sidebar.test_sidebar_help_display",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_mouse_marks_sidebar.test_sidebar_mark_list_display",
           "reasons": [
             {
               "id": "gold_fail"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_move_leftright_advanced.test_column_left_no_cycle_at_start",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_movement_functions.test_section_navigation_at_boundaries",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_movement_functions.test_section_navigation_no_delimiter",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_movement_functions.test_section_navigation_previous",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
             }
           ]
         },
@@ -5599,6 +5808,28 @@
             {
               "id": "dummy_pass",
               "timestamp": 1777387546,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_save_and_converters.test_converter_es_processes_escape_sequences",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_save_and_converters.test_converter_raw_displays_escape_sequences_as_caret_notation",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
               "user": "kilian"
             }
           ]
@@ -5660,6 +5891,347 @@
           "reasons": [
             {
               "id": "gold_fail"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_search_edge_cases.test_empty_search_pattern_forward",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_search_edge_cases.test_incremental_search_updates",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_search_edge_cases.test_invalid_regex_fallback_to_literal",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_search_edge_cases.test_multicolor_with_quoted_strings",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_search_edge_cases.test_next_search_continuation",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_search_edge_cases.test_search_not_found_message",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_search_edge_cases.test_search_numeric_only_pattern",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_search_edge_cases.test_search_symbol_only_pattern",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_search_edge_cases.test_search_wrapping_forward",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_search_edge_cases.test_smart_case_with_uppercase_in_pattern",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_tui_advanced.test_alternate_rows",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_tui_advanced.test_caption_display",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_tui_advanced.test_mark_set_and_message",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_tui_advanced.test_ruler_absolute",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_tui_advanced.test_ruler_disabled",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_tui_advanced.test_status_line_content",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_tui_advanced.test_status_line_disabled",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_tui_control_flow.test_bottom_navigation_triggers_request_bottom",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_tui_control_flow.test_exec_mode_reload_control_reader",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_tui_control_flow.test_follow_mode_request_follow",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_tui_control_flow.test_reload_file_with_f5",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_tui_control_flow.test_search_request_search",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_tui_control_flow.test_watch_mode_periodic_reload",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_tui_input_modes.test_header_column_mode",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_tui_input_modes.test_header_mode_basic",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_tui_input_modes.test_jump_target_mode",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_tui_input_modes.test_mark_goto_mode",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_tui_input_modes.test_save_buffer_requires_non_seekable",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_tui_input_modes.test_section_num_mode",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_tui_input_modes.test_skip_lines_mode",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_tui_navigation.test_basic_file_display",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
             }
           ]
         }

--- a/src/programbench/data/tasks/orf__gping.26eb5b9/tests.json
+++ b/src/programbench/data/tasks/orf__gping.26eb5b9/tests.json
@@ -2782,6 +2782,23 @@
           ]
         },
         {
+          "name": "tests.test_shortcuts.test_aws_region_shortcut_expansion",
+          "reasons": [
+            {
+              "extra": {
+                "fail": 5,
+                "note": "TUI ping-stats rendering timing race (stats not yet shown in captured frame)",
+                "pass": 15,
+                "pattern": "ffppppfpppppppppfppf",
+                "source": "20x gold cloud eval 2026-06-13"
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781326815,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_shortcuts.test_hostname_resolves_to_ipv6_with_flag",
           "reasons": [
             {

--- a/src/programbench/data/tasks/peco__peco.4e58dad/tests.json
+++ b/src/programbench/data/tasks/peco__peco.4e58dad/tests.json
@@ -455,6 +455,23 @@
           ]
         },
         {
+          "name": "eval.tests.test_basic.test_dash_in_regular_query",
+          "reasons": [
+            {
+              "extra": {
+                "fail": 1,
+                "note": "tcell screen-init race (open /dev/tty: no such device) + TUI layout snapshot timing; --select-1 exit code tty-dependent",
+                "pass": 19,
+                "pattern": "pppfpppppppppppppppp",
+                "source": "20x gold cloud eval 2026-06-13"
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781326815,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "eval.tests.test_basic.test_empty_input_with_exit_0_flag",
           "reasons": [
             {
@@ -653,6 +670,23 @@
           ]
         },
         {
+          "name": "eval.tests.test_basic.test_print_query_with_different_selection",
+          "reasons": [
+            {
+              "extra": {
+                "fail": 1,
+                "note": "tcell screen-init race (open /dev/tty: no such device) + TUI layout snapshot timing; --select-1 exit code tty-dependent",
+                "pass": 19,
+                "pattern": "pppppppppppppfpppppp",
+                "source": "20x gold cloud eval 2026-06-13"
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781326815,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "eval.tests.test_basic.test_query_case_insensitive_default",
           "reasons": [
             {
@@ -843,6 +877,23 @@
             },
             {
               "id": "gold_fail"
+            }
+          ]
+        },
+        {
+          "name": "eval.tests.test_coverage.test_config_with_initial_filter",
+          "reasons": [
+            {
+              "extra": {
+                "fail": 2,
+                "note": "tcell screen-init race (open /dev/tty: no such device) + TUI layout snapshot timing; --select-1 exit code tty-dependent",
+                "pass": 18,
+                "pattern": "pppppppppppppppppfpf",
+                "source": "20x gold cloud eval 2026-06-13"
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781326815,
+              "user": "kilian"
             }
           ]
         },
@@ -1151,6 +1202,23 @@
           ]
         },
         {
+          "name": "eval.tests.test_coverage.test_print_query_with_no_match",
+          "reasons": [
+            {
+              "extra": {
+                "fail": 2,
+                "note": "tcell screen-init race (open /dev/tty: no such device) + TUI layout snapshot timing; --select-1 exit code tty-dependent",
+                "pass": 18,
+                "pattern": "pppppfppfppppppppppp",
+                "source": "20x gold cloud eval 2026-06-13"
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781326815,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "eval.tests.test_coverage.test_prompt_with_select_1",
           "reasons": [
             {
@@ -1182,6 +1250,23 @@
             {
               "id": "gold_fail",
               "timestamp": 1777386529,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "eval.tests.test_coverage.test_query_with_emoji",
+          "reasons": [
+            {
+              "extra": {
+                "fail": 1,
+                "note": "tcell screen-init race (open /dev/tty: no such device) + TUI layout snapshot timing; --select-1 exit code tty-dependent",
+                "pass": 19,
+                "pattern": "pppfpppppppppppppppp",
+                "source": "20x gold cloud eval 2026-06-13"
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781326815,
               "user": "kilian"
             }
           ]
@@ -4872,6 +4957,40 @@
           ]
         },
         {
+          "name": "tests.test_layout_gap.test_layout_bottom_up_page_up",
+          "reasons": [
+            {
+              "extra": {
+                "fail": 1,
+                "note": "tcell screen-init race (open /dev/tty: no such device) + TUI layout snapshot timing; --select-1 exit code tty-dependent",
+                "pass": 19,
+                "pattern": "ppppfppppppppppppppp",
+                "source": "20x gold cloud eval 2026-06-13"
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781326815,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_layout_gap.test_layout_cursor_middle_of_query",
+          "reasons": [
+            {
+              "extra": {
+                "fail": 1,
+                "note": "tcell screen-init race (open /dev/tty: no such device) + TUI layout snapshot timing; --select-1 exit code tty-dependent",
+                "pass": 19,
+                "pattern": "ppppfppppppppppppppp",
+                "source": "20x gold cloud eval 2026-06-13"
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781326815,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_layout_gap.test_layout_few_lines_wrapping",
           "reasons": [
             {
@@ -5697,6 +5816,17 @@
           ]
         },
         {
+          "name": "tests.test_basic.TestSpecialCharacters.test_whitespace_only_lines",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_interactive.TestInteractiveBasic.test_basic_display",
           "reasons": [
             {
@@ -5902,7 +6032,19 @@
         "eval.tests.test_peco_behavior.test_unknown_flag_errors",
         "eval.tests.test_peco_behavior.test_version_format"
       ],
-      "ignored_tests": []
+      "ignored_tests": [
+        {
+          "name": "eval.tests.test_peco_behavior.test_prompt_option_changes_prompt",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        }
+      ]
     },
     "6c5b8939620c": {
       "ignored": false,

--- a/src/programbench/data/tasks/pls-rs__pls.4e1ae50/tests.json
+++ b/src/programbench/data/tasks/pls-rs__pls.4e1ae50/tests.json
@@ -395,6 +395,17 @@
           ]
         },
         {
+          "name": "tests.test_filtering.test_importance_filter_cutoff_0",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_filtering.test_importance_filter_cutoff_1",
           "reasons": [
             {

--- a/src/programbench/data/tasks/raviqqe__muffet.a882908/tests.json
+++ b/src/programbench/data/tasks/raviqqe__muffet.a882908/tests.json
@@ -676,6 +676,23 @@
           ]
         },
         {
+          "name": "tests.test_output_formats.test_json_empty_links_array_structure",
+          "reasons": [
+            {
+              "extra": {
+                "fail": 8,
+                "note": "local HTTP test-server dial race (error when dialing 127.0.0.1:8765)",
+                "pass": 12,
+                "pattern": "ppfffppfffppppppffpp",
+                "source": "20x gold cloud eval 2026-06-13"
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781326815,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_output_formats.test_json_error_is_string",
           "reasons": [
             {

--- a/src/programbench/data/tasks/rcoh__angle-grinder.9c2fc88/tests.json
+++ b/src/programbench/data/tasks/rcoh__angle-grinder.9c2fc88/tests.json
@@ -1268,6 +1268,42 @@
           ]
         },
         {
+          "name": "tests.test_tty_rendering.test_tty_aggregate_shows_ansi_escape_codes",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Flaky TUI render timing (progressive / ANSI tty output)",
+                "statuses": [
+                  "passed",
+                  "failure",
+                  "passed"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_tty_rendering.test_tty_avg_aggregate_shows_progressive_updates",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Flaky TUI render timing (progressive / ANSI tty output)",
+                "statuses": [
+                  "passed",
+                  "passed",
+                  "failure"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_tty_rendering.test_tty_count_aggregate_intermediate_updates",
           "reasons": [
             {

--- a/src/programbench/data/tasks/rhysd__kiro-editor.4157485/tests.json
+++ b/src/programbench/data/tasks/rhysd__kiro-editor.4157485/tests.json
@@ -1488,6 +1488,17 @@
           ]
         },
         {
+          "name": "tests.test_edge_cases.test_horizontal_scroll_on_long_line",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_edge_cases.test_large_file_navigation_to_end",
           "reasons": [
             {
@@ -1508,6 +1519,24 @@
           "reasons": [
             {
               "id": "gold_fail"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_edge_cases.test_utf8_multibyte_characters",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Flaky TUI render timing (editor screen state, utf8 input)",
+                "statuses": [
+                  "failure",
+                  "passed",
+                  "failure"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
+              "user": "kilian"
             }
           ]
         },
@@ -1734,10 +1763,46 @@
           ]
         },
         {
+          "name": "tests.test_editor_gaps.test_backspace_key_deletes_char",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Flaky TUI render timing (editor screen state, utf8 input)",
+                "statuses": [
+                  "passed",
+                  "passed",
+                  "failure"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_editor_gaps.test_ctrl_bracket_page_down",
           "reasons": [
             {
               "id": "gold_fail"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_editor_gaps.test_utf8_character_input",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Flaky TUI render timing (editor screen state, utf8 input)",
+                "statuses": [
+                  "failure",
+                  "passed",
+                  "failure"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
+              "user": "kilian"
             }
           ]
         },
@@ -1895,6 +1960,35 @@
             {
               "id": "dummy_pass",
               "timestamp": 1777387775,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_tui_core.test_backspace_deletion",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Flaky TUI render timing (editor screen state, utf8 input)",
+                "statuses": [
+                  "passed",
+                  "passed",
+                  "failure"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_tui_core.test_delete_to_end_of_line",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
               "user": "kilian"
             }
           ]

--- a/src/programbench/data/tasks/rs__curlie.5dfcbb1/tests.json
+++ b/src/programbench/data/tasks/rs__curlie.5dfcbb1/tests.json
@@ -689,6 +689,42 @@
           ]
         },
         {
+          "name": "tests.test_formatting_json.test_deep_nested_json",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Network-dependent (curl connection failures, rc=7)",
+                "statuses": [
+                  "failure",
+                  "passed",
+                  "failure"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_formatting_json.test_empty_json_array",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Network-dependent (curl connection failures, rc=7)",
+                "statuses": [
+                  "failure",
+                  "failure",
+                  "passed"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_formatting_json.test_empty_json_object",
           "reasons": [
             {
@@ -703,6 +739,17 @@
           "reasons": [
             {
               "id": "gold_fail"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_formatting_json.test_escape_sequences_in_json_strings",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
             }
           ]
         },
@@ -725,10 +772,46 @@
           ]
         },
         {
+          "name": "tests.test_formatting_json.test_literals_null_true_false_colorization",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Network-dependent (curl connection failures, rc=7)",
+                "statuses": [
+                  "failure",
+                  "passed",
+                  "failure"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_formatting_json.test_malformed_json_extra_closing_brace_negative_level_guard",
           "reasons": [
             {
               "id": "gold_fail"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_formatting_json.test_no_pretty_flag_no_formatting",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Network-dependent (curl connection failures, rc=7)",
+                "statuses": [
+                  "failure",
+                  "passed",
+                  "failure"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
+              "user": "kilian"
             }
           ]
         },
@@ -738,6 +821,52 @@
             {
               "id": "gold_fail",
               "timestamp": 1777813680,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_formatting_json.test_plain_text_passthrough",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_formatting_json.test_unicode_characters",
+          "reasons": [
+            {
+              "extra": {
+                "fail": 5,
+                "note": "curl connection race (exit 7) against local test server",
+                "pass": 15,
+                "pattern": "pffpppppppfppppfppfp",
+                "source": "20x gold cloud eval 2026-06-13"
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781326815,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_formatting_json.test_whitespace_tabs_and_carriage_returns",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Network-dependent (curl connection failures, rc=7)",
+                "statuses": [
+                  "passed",
+                  "failure",
+                  "failure"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
               "user": "kilian"
             }
           ]

--- a/src/programbench/data/tasks/rust-embedded__svd2rust.1760b5e/tests.json
+++ b/src/programbench/data/tasks/rust-embedded__svd2rust.1760b5e/tests.json
@@ -1583,7 +1583,30 @@
         "eval.tests.test_logging.test_log_info_has_two_lines",
         "eval.tests.test_logging.test_log_off_produces_no_stderr"
       ],
-      "ignored_tests": []
+      "ignored_tests": [
+        {
+          "name": "eval.tests.test_cli_help_version.test_version_exact",
+          "reasons": [
+            {
+              "id": "gold_fail",
+              "note": "[gold_fail_v6_build_stamp] Fails on v6 gold: test asserts a build-stamped version/commit/date string (non-reproducible build metadata, e.g. embedded git rev or build date) rather than functionality; the golden captured the previous build's stamp.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "eval.tests.test_generation_outputs.test_generate_default_files_and_content_hashes",
+          "reasons": [
+            {
+              "id": "gold_fail",
+              "note": "[gold_fail_v6_toolchain] Fails on v6 gold: output reflects the pinned toolchain / dependency versions (e.g. Go compiler diagnostic wording, stdlib net behavior, or generated-code content); the golden captured the previous build environment's output.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        }
+      ]
     },
     "0e234d2b8eef": {
       "ignored": false,

--- a/src/programbench/data/tasks/sheepla__pingu.926d475/tests.json
+++ b/src/programbench/data/tasks/sheepla__pingu.926d475/tests.json
@@ -373,6 +373,17 @@
           ]
         },
         {
+          "name": "tests.test_edge_cases.test_ipv4_all_zeros_resolves_to_localhost",
+          "reasons": [
+            {
+              "id": "gold_fail",
+              "note": "[gold_fail_v6_toolchain] Fails on v6 gold: output reflects the pinned toolchain / dependency versions (e.g. Go compiler diagnostic wording, stdlib net behavior, or generated-code content); the golden captured the previous build environment's output.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_edge_cases.test_ipv6_localhost",
           "reasons": [
             {
@@ -421,6 +432,50 @@
           "reasons": [
             {
               "id": "gold_fail"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_flags.test_version_format",
+          "reasons": [
+            {
+              "id": "gold_fail",
+              "note": "[gold_fail_v6_build_stamp] Fails on v6 gold: test asserts a build-stamped version/commit/date string (non-reproducible build metadata, e.g. embedded git rev or build date) rather than functionality; the golden captured the previous build's stamp.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_flags.test_version_ignores_other_flags",
+          "reasons": [
+            {
+              "id": "gold_fail",
+              "note": "[gold_fail_v6_build_stamp] Fails on v6 gold: test asserts a build-stamped version/commit/date string (non-reproducible build metadata, e.g. embedded git rev or build date) rather than functionality; the golden captured the previous build's stamp.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_flags.test_version_long_flag",
+          "reasons": [
+            {
+              "id": "gold_fail",
+              "note": "[gold_fail_v6_build_stamp] Fails on v6 gold: test asserts a build-stamped version/commit/date string (non-reproducible build metadata, e.g. embedded git rev or build date) rather than functionality; the golden captured the previous build's stamp.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_flags.test_version_short_flag",
+          "reasons": [
+            {
+              "id": "gold_fail",
+              "note": "[gold_fail_v6_build_stamp] Fails on v6 gold: test asserts a build-stamped version/commit/date string (non-reproducible build metadata, e.g. embedded git rev or build date) rather than functionality; the golden captured the previous build's stamp.",
+              "timestamp": 1749700000,
+              "user": "kilian"
             }
           ]
         },

--- a/src/programbench/data/tasks/sqlite__sqlite.839433d/tests.json
+++ b/src/programbench/data/tasks/sqlite__sqlite.839433d/tests.json
@@ -22593,6 +22593,17 @@
           ]
         },
         {
+          "name": "tests.test_harvest_e_createtable.test_e_createtable_t4_15_0@db_e_createtable",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_harvest_e_createtable.test_e_createtable_t4_18_3@db_e_createtable",
           "reasons": [
             {
@@ -33764,6 +33775,23 @@
           ]
         },
         {
+          "name": "tests.test_harvest_pragma4.test_pragma4_t4_1_1@db_pragma4",
+          "reasons": [
+            {
+              "extra": {
+                "fail": 1,
+                "note": "test-isolation race: pre-existing table/view from dirty shared DB state (table/view already exists)",
+                "pass": 19,
+                "pattern": "pppppppppfpppppppppp",
+                "source": "20x gold cloud eval 2026-06-13"
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781326815,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_harvest_pragma4.test_pragma4_t4_1_2@db_pragma4",
           "reasons": [
             {
@@ -34893,6 +34921,23 @@
           "reasons": [
             {
               "id": "gold_fail"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_harvest_rowvalue7.test_rowvalue7_t1_1",
+          "reasons": [
+            {
+              "extra": {
+                "fail": 1,
+                "note": "test-isolation race: pre-existing table/view from dirty shared DB state (table/view already exists)",
+                "pass": 19,
+                "pattern": "pppppppppppppppppfpp",
+                "source": "20x gold cloud eval 2026-06-13"
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781326815,
+              "user": "kilian"
             }
           ]
         },
@@ -41763,6 +41808,23 @@
             {
               "id": "gold_fail",
               "timestamp": 1777386531,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_harvest_window1.test_window1_t73_0",
+          "reasons": [
+            {
+              "extra": {
+                "fail": 2,
+                "note": "test-isolation race: pre-existing table/view from dirty shared DB state (table/view already exists)",
+                "pass": 18,
+                "pattern": "pppppppppppfpppppppf",
+                "source": "20x gold cloud eval 2026-06-13"
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781326815,
               "user": "kilian"
             }
           ]

--- a/src/programbench/data/tasks/stranger6667__jsonschema.d52e881/tests.json
+++ b/src/programbench/data/tasks/stranger6667__jsonschema.d52e881/tests.json
@@ -1645,6 +1645,17 @@
               "id": "gold_fail"
             }
           ]
+        },
+        {
+          "name": "tests.test_retriever.test_insecure_flag_bypasses_cert_validation",
+          "reasons": [
+            {
+              "id": "gold_fail",
+              "note": "[gold_fail_v6_toolchain] HTTP-client error wording differs from golden ('error decoding response body'); reqwest version drift (test also depends on external https://self-signed.badssl.com). 20x gold cloud eval 2026-06-13, failed 20/20 rounds",
+              "timestamp": 1781487387,
+              "user": "kilian"
+            }
+          ]
         }
       ]
     },

--- a/src/programbench/data/tasks/svenstaro__genact.16f96e3/tests.json
+++ b/src/programbench/data/tasks/svenstaro__genact.16f96e3/tests.json
@@ -244,6 +244,23 @@
       ],
       "ignored_tests": [
         {
+          "name": "tests.test_modules_misc.test_rkhunter_rootkit_scanning",
+          "reasons": [
+            {
+              "extra": {
+                "fail": 1,
+                "note": "randomized activity-simulator output: expected task line absent in a random run",
+                "pass": 19,
+                "pattern": "pppppppppppppppppppf",
+                "source": "20x gold cloud eval 2026-06-13"
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781326815,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_modules_security.test_docker_image_rm_shows_digest_after_tag",
           "reasons": [
             {

--- a/src/programbench/data/tasks/tstack__lnav.ee34494/tests.json
+++ b/src/programbench/data/tasks/tstack__lnav.ee34494/tests.json
@@ -1741,6 +1741,17 @@
           ]
         },
         {
+          "name": "tests.test_help_system.test_help_flag_basic_usage",
+          "reasons": [
+            {
+              "id": "gold_fail",
+              "note": "[gold_fail_v6_build_stamp] Usage string embeds the build git-hash (4.0-8ad2d43) differing from golden (4.0-07efb63). 20x gold cloud eval 2026-06-13, failed 20/20 rounds",
+              "timestamp": 1781487387,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_hotkeys.test_hotkey_C_clear_bookmarks",
           "reasons": [
             {

--- a/src/programbench/data/tasks/unhappychoice__gittype.34b72d0/tests.json
+++ b/src/programbench/data/tasks/unhappychoice__gittype.34b72d0/tests.json
@@ -1349,6 +1349,17 @@
           ]
         },
         {
+          "name": "tests.test_global_args.test_double_dash_separator",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_global_args.test_duplicate_languages_accepted",
           "reasons": [
             {
@@ -1401,6 +1412,17 @@
           "reasons": [
             {
               "id": "gold_fail"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_global_args.test_unknown_subcommand",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
             }
           ]
         },
@@ -1708,6 +1730,83 @@
             {
               "id": "dummy_pass",
               "timestamp": 1777387881,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_repo_paths.test_langs_all_supported_languages",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_repo_paths.test_langs_case_insensitive",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_repo_paths.test_langs_duplicate_entries",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_repo_paths.test_langs_empty_value_tries_to_start",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_repo_paths.test_langs_with_spaces_in_names",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_repo_paths.test_multiple_langs_flags_are_combined",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_repo_paths.test_no_args_requires_tty",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
               "user": "kilian"
             }
           ]
@@ -2045,6 +2144,23 @@
           ]
         },
         {
+          "name": "tests.test_tui_loading.test_current_directory_implicit_path",
+          "reasons": [
+            {
+              "extra": {
+                "fail": 11,
+                "note": "TUI loading/title-screen render timing race under tui2cli capture (title/version screen not reached in captured frame)",
+                "pass": 9,
+                "pattern": "ppppppffffffffpfpffp",
+                "source": "20x gold cloud eval 2026-06-13"
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781326815,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_tui_loading.test_difficulty_wrapping_from_hard_to_easiest",
           "reasons": [
             {
@@ -2055,10 +2171,95 @@
           ]
         },
         {
+          "name": "tests.test_tui_loading.test_loading_completes_and_reaches_title_screen",
+          "reasons": [
+            {
+              "extra": {
+                "fail": 11,
+                "note": "TUI loading/title-screen render timing race under tui2cli capture (title/version screen not reached in captured frame)",
+                "pass": 9,
+                "pattern": "ppppppffffffffpfpffp",
+                "source": "20x gold cloud eval 2026-06-13"
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781326815,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_tui_loading.test_multiple_repos_same_session_prevents_conflicts",
+          "reasons": [
+            {
+              "extra": {
+                "fail": 11,
+                "note": "TUI loading/title-screen render timing race under tui2cli capture (title/version screen not reached in captured frame)",
+                "pass": 9,
+                "pattern": "ppppppffffffffpfpffp",
+                "source": "20x gold cloud eval 2026-06-13"
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781326815,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_tui_loading.test_title_screen_difficulty_change_right_arrow",
+          "reasons": [
+            {
+              "extra": {
+                "fail": 11,
+                "note": "TUI loading/title-screen render timing race under tui2cli capture (title/version screen not reached in captured frame)",
+                "pass": 9,
+                "pattern": "ppppppffffffffpfpffp",
+                "source": "20x gold cloud eval 2026-06-13"
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781326815,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_tui_loading.test_version_check_exit_with_escape",
+          "reasons": [
+            {
+              "extra": {
+                "fail": 11,
+                "note": "TUI loading/title-screen render timing race under tui2cli capture (title/version screen not reached in captured frame)",
+                "pass": 9,
+                "pattern": "ppppppffffffffpfpffp",
+                "source": "20x gold cloud eval 2026-06-13"
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781326815,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_tui_loading.test_version_check_screen_appears_on_launch",
           "reasons": [
             {
               "id": "gold_fail"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_tui_loading.test_version_check_skip_with_space",
+          "reasons": [
+            {
+              "extra": {
+                "fail": 11,
+                "note": "TUI loading/title-screen render timing race under tui2cli capture (title/version screen not reached in captured frame)",
+                "pass": 9,
+                "pattern": "ppppppffffffffpfpffp",
+                "source": "20x gold cloud eval 2026-06-13"
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781326815,
+              "user": "kilian"
             }
           ]
         },
@@ -2077,6 +2278,40 @@
           "reasons": [
             {
               "id": "gold_fail"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_tui_records.test_records_escape_returns_to_title",
+          "reasons": [
+            {
+              "extra": {
+                "fail": 11,
+                "note": "TUI loading/title-screen render timing race under tui2cli capture (title/version screen not reached in captured frame)",
+                "pass": 9,
+                "pattern": "ppppppffffffffpfpffp",
+                "source": "20x gold cloud eval 2026-06-13"
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781326815,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_tui_records.test_records_screen_access_from_title",
+          "reasons": [
+            {
+              "extra": {
+                "fail": 11,
+                "note": "TUI loading/title-screen render timing race under tui2cli capture (title/version screen not reached in captured frame)",
+                "pass": 9,
+                "pattern": "ppppppffffffffpfpffp",
+                "source": "20x gold cloud eval 2026-06-13"
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781326815,
+              "user": "kilian"
             }
           ]
         },

--- a/src/programbench/data/tasks/y2z__monolith.8702e66/tests.json
+++ b/src/programbench/data/tasks/y2z__monolith.8702e66/tests.json
@@ -777,6 +777,17 @@
           ]
         },
         {
+          "name": "eval.tests.test_cli_operations.test_ignore_errors_flag",
+          "reasons": [
+            {
+              "id": "gold_fail",
+              "note": "[gold_fail_v6_external_resource] Inlined external resource (base64 data-URI) differs from golden; monolith fetches and embeds web content, so the result depends on a non-reproducible external page. 20x gold cloud eval 2026-06-13, failed 20/20 rounds",
+              "timestamp": 1781487387,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "eval.tests.test_cookies.test_case_insensitive_domain_matching",
           "reasons": [
             {

--- a/src/programbench/data/tasks/yassinebridi__serpl.c48a9d7/tests.json
+++ b/src/programbench/data/tasks/yassinebridi__serpl.c48a9d7/tests.json
@@ -924,6 +924,182 @@
           ]
         },
         {
+          "name": "tests.test_config_color_parsing.test_parse_color_all_named_colors",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_config_color_parsing.test_parse_color_bold_red",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_config_color_parsing.test_parse_color_bright_format",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_config_color_parsing.test_parse_color_gray_max_value",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_config_color_parsing.test_parse_color_gray_min_value",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_config_color_parsing.test_parse_color_gray_scale",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_config_color_parsing.test_parse_color_index_format",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_config_color_parsing.test_parse_color_index_max_value",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_config_color_parsing.test_parse_color_invalid_returns_none",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_config_color_parsing.test_parse_color_named_black",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_config_color_parsing.test_parse_color_rgb_all_max",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_config_color_parsing.test_parse_color_rgb_all_zeros",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_config_color_parsing.test_parse_color_rgb_format",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_config_color_parsing.test_parse_color_whitespace_trimming",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_replace_errors.test_binary_file_skipped",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_replace_errors.test_case_sensitive_edge_cases",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_replace_errors.test_empty_file_handling",
           "reasons": [
             {
@@ -937,6 +1113,50 @@
             {
               "id": "dummy_pass",
               "timestamp": 1777387881,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_replace_errors.test_files_with_special_characters_in_names",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_replace_errors.test_newline_only_file_handling",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_replace_errors.test_readonly_file_handling",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_replace_errors.test_symlink_handling",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
               "user": "kilian"
             }
           ]
@@ -962,10 +1182,38 @@
           ]
         },
         {
+          "name": "tests.test_search_advanced.test_search_simple_mode",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_search_advanced.test_search_with_special_regex_chars",
           "reasons": [
             {
               "id": "gold_fail"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_tui_basic.test_tab_navigation_between_panes",
+          "reasons": [
+            {
+              "extra": {
+                "fail": 19,
+                "note": "TUI Search/Preview pane snapshot capture timing race",
+                "pass": 1,
+                "pattern": "pfffffffffffffffffff",
+                "source": "20x gold cloud eval 2026-06-13"
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781326815,
+              "user": "kilian"
             }
           ]
         },
@@ -982,6 +1230,17 @@
           "reasons": [
             {
               "id": "gold_fail"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_tui_preview.test_preview_pane_displays_sample1_with_multiple_matches",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
+              "user": "kilian"
             }
           ]
         },
@@ -1010,6 +1269,24 @@
           ]
         },
         {
+          "name": "tests.test_tui_preview.test_preview_pane_goto_top_with_g",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Flaky TUI render timing (preview-pane navigation)",
+                "statuses": [
+                  "passed",
+                  "passed",
+                  "failure"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_tui_preview.test_preview_pane_navigate_backward_with_k",
           "reasons": [
             {
@@ -1023,6 +1300,24 @@
             {
               "id": "gold_fail",
               "timestamp": 1777813681,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_tui_preview.test_preview_pane_navigate_to_first_match_with_j",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Flaky TUI render timing (preview-pane navigation)",
+                "statuses": [
+                  "failure",
+                  "passed",
+                  "passed"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
               "user": "kilian"
             }
           ]
@@ -1043,6 +1338,28 @@
             {
               "id": "dummy_pass",
               "timestamp": 1777387881,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_tui_results.test_empty_results_list",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "TUI Search/Preview snapshot capture timing race. caught in postfix gold rerun (21st run); passed 20/20 in 20x sweep",
+              "timestamp": 1781500166,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_tui_results.test_file_deletion_with_d_key",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "Flaky on v6 gold: passed in some gold-eval rounds and failed in others across 3 independent runs (timing-sensitive TUI/tui2cli snapshot, tmux, or db-lock/test-isolation concurrency); unreliable for grading.",
+              "timestamp": 1749700000,
               "user": "kilian"
             }
           ]
@@ -1108,6 +1425,23 @@
           ]
         },
         {
+          "name": "tests.test_tui_search.test_search_tab_navigation_to_results",
+          "reasons": [
+            {
+              "extra": {
+                "fail": 19,
+                "note": "TUI Search/Preview pane snapshot capture timing race",
+                "pass": 1,
+                "pattern": "pfffffffffffffffffff",
+                "source": "20x gold cloud eval 2026-06-13"
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781326815,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_tui_suspend_resume.TestTuiSuspendResume.test_resume_reinitializes_terminal",
           "reasons": [
             {
@@ -1120,6 +1454,17 @@
           "reasons": [
             {
               "id": "gold_fail"
+            }
+          ]
+        },
+        {
+          "name": "tests.test_tui_workflows.test_empty_search_results_handling",
+          "reasons": [
+            {
+              "id": "gold_flaky",
+              "note": "TUI snapshot capture timing race (empty captured frame). caught in postfix gold rerun (21st run); passed 20/20 in 20x sweep",
+              "timestamp": 1781500166,
+              "user": "kilian"
             }
           ]
         },

--- a/src/programbench/data/tasks/ys-l__flamelens.0b4dc33/tests.json
+++ b/src/programbench/data/tasks/ys-l__flamelens.0b4dc33/tests.json
@@ -765,6 +765,24 @@
           ]
         },
         {
+          "name": "tests.test_parsing.test_readable_data_comment_visualization",
+          "reasons": [
+            {
+              "extra": {
+                "cause": "Flaky TUI render timing (flamegraph parse/render)",
+                "statuses": [
+                  "passed",
+                  "failure",
+                  "failure"
+                ]
+              },
+              "id": "gold_flaky",
+              "timestamp": 1781197573,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_parsing.test_recursive_stacks",
           "reasons": [
             {

--- a/src/programbench/data/tasks/zk-org__zk.10d93d5/tests.json
+++ b/src/programbench/data/tasks/zk-org__zk.10d93d5/tests.json
@@ -3336,6 +3336,17 @@
           ]
         },
         {
+          "name": "tests.test_list_format.test_format_oneline",
+          "reasons": [
+            {
+              "id": "gold_fail",
+              "note": "[gold_fail_v6_toolchain] list --format=oneline output deterministically differs from captured golden (identical across all 20 rounds; gold output drift). 20x gold cloud eval 2026-06-13, failed 20/20 rounds",
+              "timestamp": 1781487387,
+              "user": "kilian"
+            }
+          ]
+        },
+        {
           "name": "tests.test_list_format.test_template_format_date_helper",
           "reasons": [
             {


### PR DESCRIPTION
Port the June 2026 test-ignore updates from the internal reference harness into ProgramBench across 41 instances (+270 ignored tests total), keeping all metadata verbatim, and update CLAUDE.md accordingly.

Branch-hash keys and per-branch test name-sets are unchanged, so no test blob re-upload is needed; only ignore metadata differs. The testorg__calculator fixture is untouched.

Internal-reference-commit: 1ca7719a46b9fc521af2353e287b4f07f4c071ea
Internal-reference-commit: a8f153ad485daf95e2041b5e872b5b715b7f5410
Internal-reference-commit: b6466b9e33c2abd88ce8ca06037c876b1edcc864
Internal-reference-commit: d7f13854873fd23b60606729d649f31a4dc7d7ac
Internal-reference-commit: 7b3a00e057cc625c86bcb9988a439ae50adb0828
Internal-reference-commit: 83488589c5237b4b9af904e1809997df735106f0
Internal-reference-commit: 3bbf4632e7d5e978b817bc168fa0897d0bbc2161
Internal-reference-commit: 691dcaa75a89d8d6f22fc7253c641375df9c3bdf