### PR TITLE
fix(eval): remove stale ./executable before compile.sh

### DIFF
--- a/src/programbench/eval/eval.py
+++ b/src/programbench/eval/eval.py
@@ -492,6 +492,19 @@ class Evaluator:
         assert self.submission_archive is not None
         env.copy_in_tar(self.submission_archive, f"{WORKSPACE_DIR}/")
         self._remove_hashed_files(env, log_buf)
+        # Remove any ./executable shipped in the submission archive so the
+        # build must produce a fresh binary. The workspace wipe above runs
+        # *before* the tar is extracted, so a prebuilt executable smuggled
+        # into the submission would otherwise survive into the compile step
+        # and be stashed as if the build had produced it (a stub/no-op
+        # compile.sh would then "pass"). _remove_hashed_files only catches
+        # byte-for-byte copies of the gold binary, not arbitrary prebuilts.
+        self._run_step(
+            "rm -f ./executable",
+            env=env,
+            log_buf=log_buf,
+            step_name="clear_stale_executable",
+        )
         # Seed a synthetic git repo if the submission didn't ship one. Build
         # scripts that depend on a working tree (jq submodules, calcurse's
         # autopoint, cargo+vergen, ...) succeed against this synthetic repo.
@@ -519,19 +532,6 @@ class Evaluator:
             env=env,
             log_buf=log_buf,
             step_name="seed_git",
-        )
-        # Remove any ./executable shipped in the submission archive so the
-        # build must produce a fresh binary. The workspace wipe above runs
-        # *before* the tar is extracted, so a prebuilt executable smuggled
-        # into the submission would otherwise survive into the compile step
-        # and be stashed as if the build had produced it (a stub/no-op
-        # compile.sh would then "pass"). _remove_hashed_files only catches
-        # byte-for-byte copies of the gold binary, not arbitrary prebuilts.
-        self._run_step(
-            "rm -f ./executable",
-            env=env,
-            log_buf=log_buf,
-            step_name="clear_stale_executable",
         )
         # Block internet during compile.sh so a submission can't smuggle
         # install/download steps into its build. Test-execution containers

--- a/src/programbench/eval/eval.py
+++ b/src/programbench/eval/eval.py
@@ -520,6 +520,19 @@ class Evaluator:
             log_buf=log_buf,
             step_name="seed_git",
         )
+        # Remove any ./executable shipped in the submission archive so the
+        # build must produce a fresh binary. The workspace wipe above runs
+        # *before* the tar is extracted, so a prebuilt executable smuggled
+        # into the submission would otherwise survive into the compile step
+        # and be stashed as if the build had produced it (a stub/no-op
+        # compile.sh would then "pass"). _remove_hashed_files only catches
+        # byte-for-byte copies of the gold binary, not arbitrary prebuilts.
+        self._run_step(
+            "rm -f ./executable",
+            env=env,
+            log_buf=log_buf,
+            step_name="clear_stale_executable",
+        )
         # Block internet during compile.sh so a submission can't smuggle
         # install/download steps into its build. Test-execution containers
         # are never touched (they may legitimately need network).

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -6,11 +6,14 @@
 
 """Tests for the evaluation pipeline (data models, XML parsing, batch logic)."""
 
+from pathlib import Path
+
 import pytest
 
 from programbench.constants import TASKS_DIR
 from programbench.eval.eval import (
     EvaluationResult,
+    Evaluator,
     TestBranchError,
     TestResult,
     _process_branch_xml,
@@ -77,6 +80,46 @@ JUNIT_XML_DUP_MIXED_KIND = """\
   </testsuite>
 </testsuites>
 """
+
+
+class RecordingEnv:
+    """Fake ContainerEnvironment that records commands and echoes them back."""
+
+    def __init__(self):
+        self.commands: list[str] = []
+        self.tars_copied: list[Path] = []
+
+    def execute(self, command: str, *, timeout: int | None = None) -> dict:
+        self.commands.append(command)
+        return {"output": command, "returncode": 0, "exception_info": ""}
+
+    def copy_in_tar(self, tar_path: Path, container_path: str) -> None:
+        self.commands.append(f"__copy_in_tar__ {tar_path}")
+        self.tars_copied.append(tar_path)
+
+
+class TestCompileClearsStaleExecutable:
+    def _run_compile(self):
+        evaluator = Evaluator(tests_branches=["b1"], submission_archive=Path("submission.tar.gz"))
+        env = RecordingEnv()
+        evaluator._compile_executable(env, log_buf=[])
+        return env
+
+    def test_stale_executable_removed_before_compile(self):
+        commands = self._run_compile().commands
+        clear_idx = next(i for i, c in enumerate(commands) if c == "rm -f ./executable")
+        compile_idx = next(i for i, c in enumerate(commands) if "compile.sh" in c)
+        extract_idx = next(i for i, c in enumerate(commands) if c.startswith("__copy_in_tar__"))
+        # The clear must happen after the submission is extracted (otherwise it
+        # removes nothing) and before compile.sh runs (so the build is forced
+        # to regenerate the binary).
+        assert extract_idx < clear_idx < compile_idx
+
+    def test_workspace_wipe_precedes_extraction(self):
+        commands = self._run_compile().commands
+        wipe_idx = next(i for i, c in enumerate(commands) if c.startswith("rm -rf "))
+        extract_idx = next(i for i, c in enumerate(commands) if c.startswith("__copy_in_tar__"))
+        assert wipe_idx < extract_idx
 
 
 class TestParseTestResults:

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -6,14 +6,11 @@
 
 """Tests for the evaluation pipeline (data models, XML parsing, batch logic)."""
 
-from pathlib import Path
-
 import pytest
 
 from programbench.constants import TASKS_DIR
 from programbench.eval.eval import (
     EvaluationResult,
-    Evaluator,
     TestBranchError,
     TestResult,
     _process_branch_xml,
@@ -80,46 +77,6 @@ JUNIT_XML_DUP_MIXED_KIND = """\
   </testsuite>
 </testsuites>
 """
-
-
-class RecordingEnv:
-    """Fake ContainerEnvironment that records commands and echoes them back."""
-
-    def __init__(self):
-        self.commands: list[str] = []
-        self.tars_copied: list[Path] = []
-
-    def execute(self, command: str, *, timeout: int | None = None) -> dict:
-        self.commands.append(command)
-        return {"output": command, "returncode": 0, "exception_info": ""}
-
-    def copy_in_tar(self, tar_path: Path, container_path: str) -> None:
-        self.commands.append(f"__copy_in_tar__ {tar_path}")
-        self.tars_copied.append(tar_path)
-
-
-class TestCompileClearsStaleExecutable:
-    def _run_compile(self):
-        evaluator = Evaluator(tests_branches=["b1"], submission_archive=Path("submission.tar.gz"))
-        env = RecordingEnv()
-        evaluator._compile_executable(env, log_buf=[])
-        return env
-
-    def test_stale_executable_removed_before_compile(self):
-        commands = self._run_compile().commands
-        clear_idx = next(i for i, c in enumerate(commands) if c == "rm -f ./executable")
-        compile_idx = next(i for i, c in enumerate(commands) if "compile.sh" in c)
-        extract_idx = next(i for i, c in enumerate(commands) if c.startswith("__copy_in_tar__"))
-        # The clear must happen after the submission is extracted (otherwise it
-        # removes nothing) and before compile.sh runs (so the build is forced
-        # to regenerate the binary).
-        assert extract_idx < clear_idx < compile_idx
-
-    def test_workspace_wipe_precedes_extraction(self):
-        commands = self._run_compile().commands
-        wipe_idx = next(i for i, c in enumerate(commands) if c.startswith("rm -rf "))
-        extract_idx = next(i for i, c in enumerate(commands) if c.startswith("__copy_in_tar__"))
-        assert wipe_idx < extract_idx
 
 
 class TestParseTestResults:


### PR DESCRIPTION
## Problem

In `Evaluator._compile_executable`, the workspace wipe (`rm -rf /workspace/*`) runs **before** the submission tar is extracted (`copy_in_tar`). As a result, an `./executable` shipped inside the submission archive lands in `/workspace` *after* the wipe and survives into the compile step. The post-compile `mv ./executable ...` then stashes it as if `compile.sh` had produced it.

Failure mode: a submission that ships a prebuilt/stale `executable` plus a stub/no-op `compile.sh` (that doesn't overwrite it) would be scored against the smuggled binary. `_remove_hashed_files` only catches byte-for-byte copies of the *gold* binary, not arbitrary prebuilts, so it doesn't close this gap.

This was noticed while comparing against RevEngBench, whose git-checkout-based pipeline avoids the issue: `git clean -fdx` removes the gitignored `executable` before every build.

## Fix

Add an explicit `rm -f ./executable` step after extraction (and `_remove_hashed_files`) and before `compile.sh`, so the build is always forced to regenerate the binary — mirroring RevEngBench's clean-then-compile behavior.

## Tests

`TestCompileClearsStaleExecutable` uses a recording fake container env to assert the command ordering:
- the clear runs **after** extraction and **before** `compile.sh`
- the workspace wipe still precedes extraction

🤖 Generated with [Claude Code](https://claude.com/claude-code)