### PR TITLE
fix(eval): don't score JUnit results that match no expected test

### DIFF
--- a/src/programbench/eval/eval.py
+++ b/src/programbench/eval/eval.py
@@ -137,6 +137,9 @@ def _process_branch_xml(
     *branch_ignored* is true, the entire branch is treated as out-of-scope:
     completeness checks are skipped and no warnings are emitted, but parsed
     results are still returned (the caller filters them out later).
+
+    A parsed result matching nothing in the expected list is dropped if it passed,
+    since it cannot be credited to an expected test. Non-passing ones are kept.
     """
     parsed = parse_test_results(raw_xml, branch=branch).test_results
     results: list[TestResult] = list(parsed)
@@ -174,12 +177,16 @@ def _process_branch_xml(
         )
     unexpected = got - set(expected) - ignored_names
     if unexpected:
-        log.warning(
-            "%s: %d test(s) in JUnit XML not in tests.json",
-            tag,
-            len(unexpected),
+        # An unmatched name must never count in the submission's favour, but a failure it
+        # records has to stay visible. With no expected list there is nothing to match against.
+        kept = [t for t in results if not expected or t.name not in unexpected or not t.is_resolved]
+        detail = (
+            f"{len(unexpected)} test(s) in JUnit XML not in tests.json; "
+            f"dropped {len(results) - len(kept)} passing result(s)"
         )
-        warnings.append(f"{tag}: {len(unexpected)} test(s) in JUnit XML not in tests.json")
+        log.warning("%s: %s", tag, detail)
+        warnings.append(f"{tag}: {detail}")
+        results = kept
 
     return results, warnings
 

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -54,6 +54,19 @@ JUNIT_XML_MIXED = """\
 </testsuites>
 """
 
+JUNIT_XML_STRAY_PASS_AND_ERROR = """\
+<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+  <testsuite name="pytest" errors="1" failures="0" skipped="0" tests="3">
+    <testcase classname="tests.test_calculator" name="test_addition" time="0.01"/>
+    <testcase classname="eval.tests.test_calculator" name="test_subtraction" time="0.02"/>
+    <testcase name="pytest.internal" time="0.0">
+      <error message="INTERNALERROR">RecursionError</error>
+    </testcase>
+  </testsuite>
+</testsuites>
+"""
+
 JUNIT_XML_DUP_SAME_KIND = """\
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites>
@@ -137,6 +150,30 @@ class TestProcessBranchXml:
         tests_by_branch = {"b1": ["tests.test_calculator.test_addition"]}
         results, warnings = _process_branch_xml(JUNIT_XML_ALL_PASS, "b1", tests_by_branch)
         assert any("not in tests.json" in w for w in warnings)
+
+    def test_shifted_names_are_not_double_counted(self):
+        expected = ["tests.test_calculator.test_addition", "tests.test_calculator.test_subtraction"]
+        results, _ = _process_branch_xml(
+            JUNIT_XML_ALL_PASS.replace('classname="tests.', 'classname="eval.tests.'), "b1", {"b1": expected}
+        )
+        assert {r.name: r.status for r in results} == dict.fromkeys(expected, "not_run")
+        assert EvaluationResult(test_results=results).score == 0.0
+
+    def test_unexpected_results_are_dropped_only_when_they_passed(self):
+        results, warnings = _process_branch_xml(
+            JUNIT_XML_STRAY_PASS_AND_ERROR, "b1", {"b1": ["tests.test_calculator.test_addition"]}
+        )
+        assert [(r.name, r.status) for r in results] == [
+            ("tests.test_calculator.test_addition", "passed"),
+            ("pytest.internal", "error"),
+        ]
+        assert EvaluationResult(test_results=results).score == 0.5
+        assert warnings == ["Branch b1: 2 test(s) in JUnit XML not in tests.json; dropped 1 passing result(s)"]
+
+    def test_branch_with_no_expected_tests_keeps_its_results(self):
+        results, warnings = _process_branch_xml(JUNIT_XML_MIXED, "b1", {"b1": []})
+        assert [r.status for r in results] == ["passed", "failure", "skipped"]
+        assert warnings == ["Branch b1: 3 test(s) in JUnit XML not in tests.json; dropped 0 passing result(s)"]
 
 
 class TestCountWorkerCrashes:


### PR DESCRIPTION
## Problem

`_process_branch_xml` adds a synthetic `not_run` for every expected name missing from the JUnit XML, but keeps parsed records that match no expected name, and `score` counts both. A test whose emitted name disagrees with `tests.json` is counted twice, once as passed and once as `not_run`, so a branch that fully passed scores half.

The example run shipped in this repo has that shape. `data/test_runs/correct/testorg__calculator.abc1234` holds three passing `eval.tests.test_calculator.*` records plus three `not_run` for the same three tests, and scores 50.

It runs the other way too: unmatched records that passed land in the numerator, so a stray `conftest.py` collecting extra items raises a score.

## Fix

Drop an unmatched record only if it passed, and only when the branch has an expected list. The warning now also reports how many results were dropped, so a removed record is recorded in `eval.json` rather than just gone.

Both conditions came out of testing rather than design:

- Dropping every unmatched record deletes pytest's own breakage markers (`pytest.internal`, empty `classname` on a collection error) and takes a broken run from 0.50 to 1.00.
- 26 non-ignored branches ship `"tests": []`. Without the guard they lose every passing record, taking a real ffmpeg branch from 0.75 to 0.00.

## What it changes, including the parts that look bad

Replaying the two `eval.json` files attached to #56: **68.44 on `main`, 54.03 with this patch**. It moves the reporter's number **down**. I think that is right, since the branch genuinely failed to verify those tests under the names it was told to expect, but it is the opposite of what #56 asks for.

Three more things you would find yourself, so I would rather list them:

1. `programbench eval --summarize-only` on `data/test_runs/correct` goes from 50 to **0** and rewrites that `eval.json` to three `not_run` records. That demo was recorded from a run whose names had already shifted, so it is an instance of this bug rather than a casualty of the fix, but neither `main` (50) nor this patch (0) reports its true 100. I did not touch it, since regenerating it properly needs a real eval. Happy to if you want it in here.
2. Under a full name shift `main` returns half the true pass rate, which still ranks submissions. This returns 0 for that branch regardless of quality. The signal goes from misleading-but-ordered to honest-but-flat.
3. `_summary_from_existing` re-parses stored XML and rewrites `eval.json` in place, so a submission packaged before this and re-summarized after can fail the tier-0 `verify` comparison. The warning string also changes, so any stored `eval.json` re-summarized after this will carry the new wording.

I left the name mismatch itself alone. The cause is not in the metadata, and I will write that up separately on #56.

## Tests

Three in `TestProcessBranchXml`, all three fail against `main`. `uv run pytest` green (68), `ruff check` and `ruff format` clean at the pinned 0.15.7.

Refs #56
