### PR TITLE
fix(eval): match JUnit names ignoring optional eval. prefix

### DIFF
--- a/src/programbench/eval/eval.py
+++ b/src/programbench/eval/eval.py
@@ -122,6 +122,17 @@ def count_testcases(raw_xml: str) -> int:
     return sum(1 for _ in root.iter("testcase"))
 
 
+def _canonical_test_name(name: str) -> str:
+    """Strip an optional leading ``eval.`` package root from a test name.
+
+    ``tests.json`` is inconsistent about the package root: some tasks store
+    ``eval.tests.foo`` (pytest's module path under /workspace/eval) while
+    others store ``tests.foo``. JUnit classnames are always rooted at
+    ``eval.tests.foo``, so both sides are compared in this canonical form.
+    """
+    return name[5:] if name.startswith("eval.") else name
+
+
 def _process_branch_xml(
     raw_xml: str,
     branch: str,
@@ -152,10 +163,12 @@ def _process_branch_xml(
         warnings.append(f"{tag}: no expected test list, cannot verify completeness")
         return results, warnings
 
-    ignored_names = {n.split("/", 1)[1] for n in (ignored_tests or set()) if n.startswith(f"{branch}/")}
-    expected_active = [n for n in expected if n not in ignored_names]
-    got = {t.name for t in parsed}
-    missing = [name for name in expected_active if name not in got]
+    ignored_names = {
+        _canonical_test_name(n.split("/", 1)[1]) for n in (ignored_tests or set()) if n.startswith(f"{branch}/")
+    }
+    expected_active = [n for n in expected if _canonical_test_name(n) not in ignored_names]
+    got = {_canonical_test_name(t.name) for t in parsed}
+    missing = [name for name in expected_active if _canonical_test_name(name) not in got]
     if missing:
         log.warning(
             "%s: %d/%d expected tests missing from JUnit XML",
@@ -172,7 +185,7 @@ def _process_branch_xml(
             )
             for name in missing
         )
-    unexpected = got - set(expected) - ignored_names
+    unexpected = got - {_canonical_test_name(n) for n in expected} - ignored_names
     if unexpected:
         log.warning(
             "%s: %d test(s) in JUnit XML not in tests.json",

--- a/src/programbench/eval/eval_batch.py
+++ b/src/programbench/eval/eval_batch.py
@@ -32,7 +32,7 @@ from tqdm import tqdm
 from tqdm.contrib.logging import logging_redirect_tqdm
 
 from programbench.constants import DOCKER_CPUS
-from programbench.eval.eval import EvaluationResult, Evaluator
+from programbench.eval.eval import EvaluationResult, Evaluator, _canonical_test_name
 from programbench.utils.instance_filters import filter_instances
 
 log = logging.getLogger(__name__)
@@ -179,8 +179,10 @@ def get_branches_to_eval(
             continue
         expected = tests_by_branch.get(branch, [])
         active_expected = [t for t in expected if f"{branch}/{t}" not in ignored_tests]
-        present = {t.name for t in existing.test_results if t.branch == branch and t.status != "not_run"}
-        if any(t not in present for t in active_expected):
+        present = {
+            _canonical_test_name(t.name) for t in existing.test_results if t.branch == branch and t.status != "not_run"
+        }
+        if any(_canonical_test_name(t) not in present for t in active_expected):
             needs_eval.append(branch)
     return needs_eval
 

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -39,6 +39,16 @@ JUNIT_XML_ALL_PASS = """\
 </testsuites>
 """
 
+JUNIT_XML_EVAL_PREFIX = """\
+<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+  <testsuite name="pytest" errors="0" failures="0" skipped="0" tests="2">
+    <testcase classname="eval.tests.test_calculator" name="test_addition" time="0.01"/>
+    <testcase classname="eval.tests.test_calculator" name="test_subtraction" time="0.02"/>
+  </testsuite>
+</testsuites>
+"""
+
 JUNIT_XML_MIXED = """\
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites>
@@ -137,6 +147,31 @@ class TestProcessBranchXml:
         tests_by_branch = {"b1": ["tests.test_calculator.test_addition"]}
         results, warnings = _process_branch_xml(JUNIT_XML_ALL_PASS, "b1", tests_by_branch)
         assert any("not in tests.json" in w for w in warnings)
+
+    def test_eval_prefix_namespace_mismatch_matches(self):
+        tests_by_branch = {
+            "b1": [
+                "tests.test_calculator.test_addition",
+                "tests.test_calculator.test_subtraction",
+            ]
+        }
+        results, warnings = _process_branch_xml(JUNIT_XML_EVAL_PREFIX, "b1", tests_by_branch)
+        assert len(results) == 2
+        assert all(r.status == "passed" for r in results)
+        assert not any(r.status == "not_run" for r in results)
+        assert not any("not in tests.json" in w for w in warnings)
+
+    def test_eval_prefix_missing_still_not_run(self):
+        tests_by_branch = {
+            "b1": [
+                "tests.test_calculator.test_addition",
+                "tests.test_calculator.test_missing",
+            ]
+        }
+        results, warnings = _process_branch_xml(JUNIT_XML_EVAL_PREFIX, "b1", tests_by_branch)
+        by_name = {r.name: r for r in results}
+        assert by_name["tests.test_calculator.test_missing"].status == "not_run"
+        assert by_name["eval.tests.test_calculator.test_addition"].status == "passed"
 
 
 class TestCountWorkerCrashes:
@@ -268,6 +303,25 @@ class TestGetBranchesToEval:
             tests_by_branch={"b1": ["t1"]},
             ignored_tests=set(),
         ) == ["b1"]
+
+    def test_namespace_mismatch_considered_evaluated(self, tmp_path):
+        eval_json = tmp_path / "eval.json"
+        result = EvaluationResult(
+            test_results=[
+                TestResult(name="eval.tests.t1.test_a", branch="b1", status="passed", extra={}),
+            ],
+            test_branches=["b1"],
+        )
+        eval_json.write_text(result.model_dump_json())
+        assert (
+            get_branches_to_eval(
+                eval_json=eval_json,
+                all_test_branches=["b1"],
+                tests_by_branch={"b1": ["tests.t1.test_a"]},
+                ignored_tests=set(),
+            )
+            == []
+        )
 
 
 class TestInstanceEvalSummary:


### PR DESCRIPTION
## Problem

The evaluator compares the expected test list in `tests.json` against JUnit classnames literally, but the two disagree on the package root. `tests.json` is inconsistent: some tasks store `eval.tests.foo` (csview) while others store `tests.foo` (cmatrix, the bundled calculator fixture). JUnit classnames are always rooted at `eval.tests.foo` because pytest collects the suite from `/workspace/eval`.

For tasks whose metadata omits the prefix, `_process_branch_xml` therefore treats every test as both:

1. missing from the XML, injecting a synthetic `not_run` record, and
2. unexpected in the XML, emitting a "not in tests.json" warning.

A branch that fully passed is counted twice and scores half. The bundled fixture `data/test_runs/correct/testorg__calculator.abc1234` reproduces this exactly: three passing `eval.tests.*` records plus three `not_run` `tests.*` records. The same literal comparison in `get_branches_to_eval` makes a completed branch look incomplete, so `programbench eval` re-runs it on every non-`--force` pass.

## Fix

Compare test names in a canonical form that strips an optional leading `eval.` prefix from both sides. Added `_canonical_test_name` and applied it to the expected/observed matching in `_process_branch_xml` and `get_branches_to_eval`. Parsed result names are left unchanged, so existing `eval.json` files and ignored-test filtering are unaffected.

## Verification

- New regression tests in `tests/test_eval.py` (namespace mismatch matches, missing test still `not_run`, re-eval idempotent) fail on `main` and pass with the fix.
- Full suite: 68 passed.
- `ruff check` and `ruff format --check` clean at 0.15.7.

Refs #56